### PR TITLE
CPU: Decode `Branch` instruction

### DIFF
--- a/src/arm7tdmi.rs
+++ b/src/arm7tdmi.rs
@@ -1,4 +1,8 @@
-use crate::{condition::Condition, cpsr::Cpsr, cpu::Cpu};
+use crate::{
+    condition::Condition,
+    cpsr::Cpsr,
+    cpu::{Cpu, InstructionKind},
+};
 
 pub(crate) struct Arm7tdmi {
     data: Vec<u8>,
@@ -19,15 +23,26 @@ impl Cpu for Arm7tdmi {
             .unwrap();
 
         let op_code = u32::from_le_bytes(data_instruction);
+        println!();
         println!("opcode -> {:b}", op_code);
 
         op_code
     }
 
-    fn decode(&self, op_code: Self::OpCodeType) -> Condition {
-        let condition: u8 = (op_code >> 28) as u8; // bit 31..=28
+    fn decode(&self, op_code: Self::OpCodeType) -> (Condition, InstructionKind) {
+        let condition = (op_code >> 28) as u8; // bit 31..=28
+        let instruction = if (op_code & 0x0A_00_00_00) != 0 {
+            if (op_code & 0x01_00_00_00) != 0 {
+                InstructionKind::BranchLink
+            } else {
+                InstructionKind::Branch
+            }
+        } else {
+            todo!()
+        };
         println!("condition -> {:x}", condition);
-        condition.into()
+        println!("instruction -> {:?}", instruction);
+        (condition.into(), instruction)
     }
 
     fn execute(&self) {}
@@ -36,7 +51,7 @@ impl Cpu for Arm7tdmi {
         let op_code = self.fetch();
 
         let condition = self.decode(op_code);
-        if self.cpsr.can_execute(condition) {
+        if self.cpsr.can_execute(condition.0) {
             todo!("we can execute now")
         }
     }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1,16 +1,21 @@
 use crate::condition::Condition;
 
+#[derive(Debug)]
+pub(crate) enum InstructionKind {
+    Branch,
+    BranchLink,
+}
+
 pub(crate) trait Cpu {
-    
     // Size of Opcode: it can to change.
     type OpCodeType;
 
     // It generally takes the next instruction from PC
     fn fetch(&self) -> Self::OpCodeType;
 
-    // It decodes the instruction to understand the 
+    // It decodes the instruction to understand the
     // OpCode and the variables
-    fn decode(&self, op_code: Self::OpCodeType) -> Condition;
+    fn decode(&self, op_code: Self::OpCodeType) -> (Condition, InstructionKind);
 
     // It executes the opcode and updates registers and memory
     fn execute(&self);


### PR DESCRIPTION
Now our CPU recognize if instruction is `Branch` or `BranchLink`.

Signed-off-by: Federico Guerinoni <guerinoni.federico@gmail.com>
Co-authored-by: Davide Gallotti <d.gallotti@outlook.it>
Co-authored-by: Alessandro Grassi <alessandrograssi17@gmail.com>
