### PR TITLE
CI: Don't trigger GitHub Action on docs changes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,8 +3,12 @@ name: Rust
 on:
   push:
     branches: [ "main" ]
+    paths:
+      - 'src/**/*'
   pull_request:
     branches: [ "main" ]
+    paths:
+      - 'src/**/*'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
In this way we can save lot of resources.
