### PR TITLE
cartridge_headers: Add all cartridge headers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.rs eol=lf

--- a/src/cartridge_header.rs
+++ b/src/cartridge_header.rs
@@ -177,6 +177,7 @@ impl CartridgeHeader {
     // Bytes:   1
     // Info:    header checksum, required!
     fn extract_complement_check(data: &[u8]) -> [u8; 1] {
+        // TODO: Do we check if extract_complement_check header (data[0x0BD..=0x0BD]) is correct?
         data[0x0BD..=0x0BD]
             .try_into()
             .expect("extracting complement check")

--- a/src/cartridge_header.rs
+++ b/src/cartridge_header.rs
@@ -1,9 +1,3 @@
-// Points to be clarified:
-// 1. BIOS must be able to overwrite the boot_mode header, as defined in the extract_boot_mode function comments; 
-// 2. BIOS must be able to overwrite the slave_id_number header, as defined in the extract_slave_id_number function comments; 
-// 3. If the GBA has been booted by using Joybus transfer mode, we have to put our initialization procedure directly at joybus_mode_entry_point address,
-//    or redirect to the actual boot procedure by depositing a "B <start>" opcode in the space used by joybus_mode_entry_point.
-
 pub(crate) struct CartridgeHeader {
     pub(crate) rom_entry_point: [u8; 4],
     pub(crate) nintendo_logo: [u8; 156],

--- a/src/cartridge_header.rs
+++ b/src/cartridge_header.rs
@@ -11,7 +11,6 @@ pub(crate) struct CartridgeHeader {
     pub(crate) software_version: [u8; 1],
     pub(crate) complement_check: [u8; 1],
     pub(crate) reserved_area_2: [u8; 2],
-    // --- Additional Multiboot Header Entries ---
     pub(crate) ram_entry_point: [u8; 4],
     pub(crate) boot_mode: [u8; 1],
     pub(crate) slave_id_number: [u8; 1],
@@ -33,7 +32,6 @@ impl CartridgeHeader {
         let software_version = Self::extract_software_version(data);
         let complement_check = Self::extract_complement_check(data);
         let reserved_area_2 = Self::extract_reserved_area_2(data);
-        // --- Additional Multiboot Header Entries ---
         let ram_entry_point = Self::extract_ram_entry_point(data);
         let boot_mode = Self::extract_boot_mode(data);
         let slave_id_number = Self::extract_slave_id_number(data);
@@ -55,7 +53,6 @@ impl CartridgeHeader {
             software_version,
             complement_check,
             reserved_area_2,
-            // --- Additional Multiboot Header Entries ---
             ram_entry_point,
             boot_mode,
             slave_id_number,
@@ -159,8 +156,6 @@ impl CartridgeHeader {
             .try_into()
             .expect("extracting reserved area 2")
     }
-
-    // --- Additional Multiboot Header Entries ---
 
     // 32bit ARM branch opcode, eg. "B ram_start"
     fn extract_ram_entry_point(data: &[u8]) -> [u8; 4] {

--- a/src/cartridge_header.rs
+++ b/src/cartridge_header.rs
@@ -80,9 +80,8 @@ impl CartridgeHeader {
         let game_title_bytes: [u8; 12] = data[0x0A0..=0x0AB]
             .try_into()
             .expect("extracting game title");
-        
-        String::from_utf8(game_title_bytes.into())
-            .expect("parsing game title")
+
+        String::from_utf8(game_title_bytes.into()).expect("parsing game title")
     }
 
     // uppercase ascii, 4 characters
@@ -90,20 +89,17 @@ impl CartridgeHeader {
         let game_code_bytes: [u8; 4] = data[0x0AC..=0x0AF]
             .try_into()
             .expect("extracting game code");
-        
-        String::from_utf8(game_code_bytes.into())
-            .expect("parsing game code")
+
+        String::from_utf8(game_code_bytes.into()).expect("parsing game code")
     }
 
-    
     // uppercase ascii, 2 characters
     fn extract_marker_code(data: &[u8]) -> String {
         let marker_code_bytes: [u8; 2] = data[0x0B0..=0x0B1]
             .try_into()
             .expect("extracting marker code");
-        
-        String::from_utf8(marker_code_bytes.into())
-            .expect("parsing marker code")
+
+        String::from_utf8(marker_code_bytes.into()).expect("parsing marker code")
     }
 
     // must be 96h, required!
@@ -127,7 +123,6 @@ impl CartridgeHeader {
             .expect("extracting device type")
     }
 
-    
     // should be zero filled
     fn extract_reserved_area_1(data: &[u8]) -> [u8; 7] {
         data[0x0B5..=0x0BB]
@@ -159,7 +154,7 @@ impl CartridgeHeader {
 
     // 32bit ARM branch opcode, eg. "B ram_start"
     fn extract_ram_entry_point(data: &[u8]) -> [u8; 4] {
-        // This entry is used only if the GBA has been booted 
+        // This entry is used only if the GBA has been booted
         // by using Normal or Multiplay transfer mode (but not by Joybus mode).
         data[0x0C0..=0x0C3]
             .try_into()
@@ -168,13 +163,13 @@ impl CartridgeHeader {
 
     // init as 00h - BIOS overwrites this value!
     fn extract_boot_mode(data: &[u8]) -> [u8; 1] {
-        // The slave GBA download procedure overwrites this byte by a value which is indicating 
+        // The slave GBA download procedure overwrites this byte by a value which is indicating
         // the used multiboot transfer mode.
         // Value  Expl.
         // 01h    Joybus mode
         // 02h    Normal mode
         // 03h    Multiplay mode
-        // Be sure that your uploaded program does not contain important 
+        // Be sure that your uploaded program does not contain important
         // program code or data at this location, or at the ID-byte location below.
         data[0x0C4..=0x0C4]
             .try_into()
@@ -183,14 +178,14 @@ impl CartridgeHeader {
 
     // init as 00h - BIOS overwrites this value!
     fn extract_slave_id_number(data: &[u8]) -> [u8; 1] {
-        // If the GBA has been booted in Normal or Multiplay mode, 
+        // If the GBA has been booted in Normal or Multiplay mode,
         // this byte becomes overwritten by the slave ID number of the local GBA
         // (that'd be always 01h for normal mode).
         // Value  Expl.
         // 01h    Slave #1
         // 02h    Slave #2
         // 03h    Slave #3
-        // When booted in Joybus mode, the value is NOT changed and 
+        // When booted in Joybus mode, the value is NOT changed and
         // remains the same as uploaded from the master GBA.
         data[0x0C5..=0x0C5]
             .try_into()
@@ -199,17 +194,15 @@ impl CartridgeHeader {
 
     // seems to be unused
     fn extract_not_used(data: &[u8]) -> [u8; 26] {
-        data[0x0C6..=0x0DF]
-            .try_into()
-            .expect("extracting not used")
+        data[0x0C6..=0x0DF].try_into().expect("extracting not used")
     }
 
     // 32bit ARM branch opcode, eg. "B joy_start"
     fn extract_joybus_mode_entry_point(data: &[u8]) -> [u8; 4] {
-        // If the GBA has been booted by using Joybus transfer mode, 
-        // then the entry point is located at this address rather than at 20000C0h (ram_entry_point - data[0x0C0..=0x0C3]). 
-        // Either put your initialization procedure directly at this address, or redirect 
-        // to the actual boot procedure by depositing a "B <start>" opcode here (either one using 32bit ARM code). 
+        // If the GBA has been booted by using Joybus transfer mode,
+        // then the entry point is located at this address rather than at 20000C0h (ram_entry_point - data[0x0C0..=0x0C3]).
+        // Either put your initialization procedure directly at this address, or redirect
+        // to the actual boot procedure by depositing a "B <start>" opcode here (either one using 32bit ARM code).
         // Or, if you are not intending to support joybus mode (which is probably rarely used), ignore this entry.
         data[0x0E0..=0x0E3]
             .try_into()

--- a/src/cartridge_header.rs
+++ b/src/cartridge_header.rs
@@ -7,8 +7,10 @@ pub(crate) struct CartridgeHeader {
     pub(crate) fixed_value: [u8; 1],
     pub(crate) main_unit_code: [u8; 1],
     pub(crate) device_type: [u8; 1],
-    pub(crate) reserved_area: [u8; 1],
+    pub(crate) reserved_area_1: [u8; 7],
     pub(crate) software_version: [u8; 1],
+    pub(crate) complement_check: [u8; 1],
+    pub(crate) reserved_area_2: [u8; 2],
 }
 
 impl CartridgeHeader {
@@ -17,13 +19,14 @@ impl CartridgeHeader {
         let nintendo_logo = Self::extract_nintendo_logo(data);
         let game_title = Self::extract_game_title(data);
         let game_code = Self::extract_game_code(data);
-        // --- Add ---
         let marker_code = Self::extract_marker_code(data);
         let fixed_value = Self::extract_fixed_value(data);
         let main_unit_code = Self::extract_main_unit_code(data);
         let device_type = Self::extract_device_type(data);
-        let reserved_area = Self::extract_reserved_area(data);
+        let reserved_area_1 = Self::extract_reserved_area_1(data);
         let software_version = Self::extract_software_version(data);
+        let complement_check = Self::extract_complement_check(data);
+        let reserved_area_2 = Self::extract_reserved_area_2(data);
 
 
         verify_checksum(data).expect("Invalid checksum");
@@ -33,13 +36,14 @@ impl CartridgeHeader {
             nintendo_logo,
             game_title,
             game_code,
-            // --- Add ---
             marker_code,
             fixed_value,
             main_unit_code,
             device_type,
-            reserved_area,
+            reserved_area_1,
             software_version,
+            complement_check,
+            reserved_area_2,
         }
     }
 
@@ -85,8 +89,6 @@ impl CartridgeHeader {
             .expect("parsing game code")
     }
 
-    // --- Add ---
-
     // Address: 0B0h
     // Bytes:   2
     // Info:    uppercase ascii, 2 characters
@@ -114,7 +116,7 @@ impl CartridgeHeader {
     // Info:    00h for current GBA models
     fn extract_main_unit_code(data: &[u8]) -> [u8; 1] {
         // TODO: Do we check if data[0x0B2..=0x0B2] is equals to 00h?
-        data[0x0B3..=0x0B4]
+        data[0x0B3..=0x0B3]
             .try_into()
             .expect("extracting main unit code")
     }
@@ -123,7 +125,7 @@ impl CartridgeHeader {
     // Bytes:   1
     // Info:    usually 00h (bit7=DACS/debug related)
     fn extract_device_type(data: &[u8]) -> [u8; 1] {
-        data[0x0B4..=0x0B5]
+        data[0x0B4..=0x0B4]
             .try_into()
             .expect("extracting device type")
     }
@@ -131,22 +133,39 @@ impl CartridgeHeader {
     // Address: 0B5h
     // Bytes:   7
     // Info:    should be zero filled
-    fn extract_reserved_area(data: &[u8]) -> [u8; 7] {
+    fn extract_reserved_area_1(data: &[u8]) -> [u8; 7] {
         data[0x0B5..=0x0BB]
             .try_into()
-            .expect("extracting reserved area")
+            .expect("extracting reserved area 1")
     }
 
     // Address: 0BCh
     // Bytes:   1
     // Info:    usually 00h
-    fn extract_software_version(data: &[u8; 1]) -> [u8; 1] {
+    fn extract_software_version(data: &[u8]) -> [u8; 1] {
         // TODO: Do we check if data[0x0B2..=0x0B2] is equals to 00h?
-        data[0x0BC..=0x0BC]
+        data[0x0BC..=0x0Bc]
             .try_into()
             .expect("extracting software version")
     }
 
+    // Address: 0BDh
+    // Bytes:   1
+    // Info:    header checksum, required!
+    fn extract_complement_check(data: &[u8]) -> [u8; 1] {
+        data[0x0BD..=0x0BE]
+            .try_into()
+            .expect("extracting complement check")
+    }
+
+    // Address: 0BEh
+    // Bytes:   2
+    // Info:    should be zero filled
+    fn extract_reserved_area_2(data: &[u8]) -> [u8; 2] {
+        data[0x0BE..=0x0BF]
+            .try_into()
+            .expect("extracting reserved area 2")
+    }
 
 }
 

--- a/src/cartridge_header.rs
+++ b/src/cartridge_header.rs
@@ -1,3 +1,10 @@
+// Points to be clarified:
+// 1. Do we want to check that the value is correct in the appropriate functions? (e.g., extract_fixed_value)
+// 2. BIOS must be able to overwrite the boot_mode header, as defined in the extract_boot_mode function comments; 
+// 3. BIOS must be able to overwrite the slave_id_number header, as defined in the extract_slave_id_number function comments; 
+// 4. If the GBA has been booted by using Joybus transfer mode, we have to put our initialization procedure directly at joybus_mode_entry_point address,
+//    or redirect to the actual boot procedure by depositing a "B <start>" opcode in the space used by joybus_mode_entry_point.
+
 pub(crate) struct CartridgeHeader {
     pub(crate) rom_entry_point: [u8; 4],
     pub(crate) nintendo_logo: [u8; 156],
@@ -11,6 +18,12 @@ pub(crate) struct CartridgeHeader {
     pub(crate) software_version: [u8; 1],
     pub(crate) complement_check: [u8; 1],
     pub(crate) reserved_area_2: [u8; 2],
+    // --- Additional Multiboot Header Entries ---
+    pub(crate) ram_entry_point: [u8; 4],
+    pub(crate) boot_mode: [u8; 1],
+    pub(crate) slave_id_number: [u8; 1],
+    pub(crate) not_used: [u8; 26],
+    pub(crate) joybus_mode_entry_point: [u8; 4],
 }
 
 impl CartridgeHeader {
@@ -27,7 +40,12 @@ impl CartridgeHeader {
         let software_version = Self::extract_software_version(data);
         let complement_check = Self::extract_complement_check(data);
         let reserved_area_2 = Self::extract_reserved_area_2(data);
-
+        // --- Additional Multiboot Header Entries ---
+        let ram_entry_point = Self::extract_ram_entry_point(data);
+        let boot_mode = Self::extract_boot_mode(data);
+        let slave_id_number = Self::extract_slave_id_number(data);
+        let not_used = Self::extract_not_used(data);
+        let joybus_mode_entry_point = Self::extract_joybus_mode_entry_point(data);
 
         verify_checksum(data).expect("Invalid checksum");
 
@@ -44,16 +62,22 @@ impl CartridgeHeader {
             software_version,
             complement_check,
             reserved_area_2,
+            // --- Additional Multiboot Header Entries ---
+            ram_entry_point,
+            boot_mode,
+            slave_id_number,
+            not_used,
+            joybus_mode_entry_point,
         }
     }
 
     // Address: 000h
     // Bytes:   4
-    // Info:    32bit ARM branch opcode
+    // Info:    32bit ARM branch opcode, eg. "B rom_start"
     fn extract_rom_entry_point(data: &[u8]) -> [u8; 4] {
         data[0x000..=0x003]
             .try_into()
-            .expect("extracting ROM entry point")
+            .expect("extracting rom entry point")
     }
 
     // Address: 004h
@@ -105,7 +129,7 @@ impl CartridgeHeader {
     // Bytes:   1
     // Info:    must be 96h, required!
     fn extract_fixed_value(data: &[u8]) -> [u8; 1] {
-        // TODO: Do we check if data[0x0B2..=0x0B2] is equals to 96h?
+        // TODO: Do we check if fixed_value header (data[0x0B2..=0x0B2]) is equals to 96h?
         data[0x0B2..=0x0B2]
             .try_into()
             .expect("extracting fixed value")
@@ -115,7 +139,7 @@ impl CartridgeHeader {
     // Bytes:   1
     // Info:    00h for current GBA models
     fn extract_main_unit_code(data: &[u8]) -> [u8; 1] {
-        // TODO: Do we check if data[0x0B2..=0x0B2] is equals to 00h?
+        // TODO: Do we check if main_unit_code header (data[0x0B2..=0x0B2]) is equals to 00h?
         data[0x0B3..=0x0B3]
             .try_into()
             .expect("extracting main unit code")
@@ -143,8 +167,8 @@ impl CartridgeHeader {
     // Bytes:   1
     // Info:    usually 00h
     fn extract_software_version(data: &[u8]) -> [u8; 1] {
-        // TODO: Do we check if data[0x0B2..=0x0B2] is equals to 00h?
-        data[0x0BC..=0x0Bc]
+        // TODO: Do we check if software_version header (data[0x0B2..=0x0B2]) is equals to 00h?
+        data[0x0BC..=0x0BC]
             .try_into()
             .expect("extracting software version")
     }
@@ -153,7 +177,7 @@ impl CartridgeHeader {
     // Bytes:   1
     // Info:    header checksum, required!
     fn extract_complement_check(data: &[u8]) -> [u8; 1] {
-        data[0x0BD..=0x0BE]
+        data[0x0BD..=0x0BD]
             .try_into()
             .expect("extracting complement check")
     }
@@ -167,6 +191,80 @@ impl CartridgeHeader {
             .expect("extracting reserved area 2")
     }
 
+    // --- Additional Multiboot Header Entries ---
+
+    // Address: 0C0h
+    // Bytes:   4
+    // Info:    32bit ARM branch opcode, eg. "B ram_start"
+    fn extract_ram_entry_point(data: &[u8]) -> [u8; 4] {
+        // This entry is used only if the GBA has been booted 
+        // by using Normal or Multiplay transfer mode (but not by Joybus mode).
+        data[0x0C0..=0x0C3]
+            .try_into()
+            .expect("extracting ram entry point")
+    }
+
+    // Address: 0C4h 
+    // Bytes:   1
+    // Info:    init as 00h - BIOS overwrites this value!
+    fn extract_boot_mode(data: &[u8]) -> [u8; 1] {
+        // TODO: Do we check if boot_mode header (data[0x0C4..=0x0C4]) is equals to 00h?
+
+        // The slave GBA download procedure overwrites this byte by a value which is indicating 
+        // the used multiboot transfer mode.
+        // Value  Expl.
+        // 01h    Joybus mode
+        // 02h    Normal mode
+        // 03h    Multiplay mode
+        // Be sure that your uploaded program does not contain important 
+        // program code or data at this location, or at the ID-byte location below.
+        data[0x0C4..=0x0C4]
+            .try_into()
+            .expect("extracting boot mode")
+    }
+
+    // Address: 0C5h
+    // Bytes:   1
+    // Info:    init as 00h - BIOS overwrites this value!
+    fn extract_slave_id_number(data: &[u8]) -> [u8; 1] {
+        // TODO: Do we check if slave_id_number header (data[0x0C5..=0x0C5]) is equals to 00h?
+
+        // If the GBA has been booted in Normal or Multiplay mode, 
+        // this byte becomes overwritten by the slave ID number of the local GBA
+        // (that'd be always 01h for normal mode).
+        // Value  Expl.
+        // 01h    Slave #1
+        // 02h    Slave #2
+        // 03h    Slave #3
+        // When booted in Joybus mode, the value is NOT changed and 
+        // remains the same as uploaded from the master GBA.
+        data[0x0C5..=0x0C5]
+            .try_into()
+            .expect("extracting slave id number")
+    }
+
+    // Address: 0C6h
+    // Bytes:   26
+    // Info:    seems to be unused
+    fn extract_not_used(data: &[u8]) -> [u8; 26] {
+        data[0x0C6..=0x0DF]
+            .try_into()
+            .expect("extracting not used")
+    }
+
+    // Address: 0E0h
+    // Bytes:   4
+    // Info:    32bit ARM branch opcode, eg. "B joy_start"
+    fn extract_joybus_mode_entry_point(data: &[u8]) -> [u8; 4] {
+        // If the GBA has been booted by using Joybus transfer mode, 
+        // then the entry point is located at this address rather than at 20000C0h (ram_entry_point - data[0x0C0..=0x0C3]). 
+        // Either put your initialization procedure directly at this address, or redirect 
+        // to the actual boot procedure by depositing a "B <start>" opcode here (either one using 32bit ARM code). 
+        // Or, if you are not intending to support joybus mode (which is probably rarely used), ignore this entry.
+        data[0x0E0..=0x0E3]
+            .try_into()
+            .expect("extracting joybus mode entry point")
+    }
 }
 
 fn verify_checksum(data: &[u8]) -> Result<(), ()> {

--- a/src/cartridge_header.rs
+++ b/src/cartridge_header.rs
@@ -1,52 +1,101 @@
 pub(crate) struct CartridgeHeader {
-    pub(crate) entry_point: [u8; 4],
+    pub(crate) rom_entry_point: [u8; 4],
     pub(crate) nintendo_logo: [u8; 156],
     pub(crate) game_title: String,
     pub(crate) game_code: String,
+    pub(crate) marker_code: String,
 }
 
 impl CartridgeHeader {
     pub fn new(data: &[u8]) -> Self {
-        let entry_point = Self::extract_entry_point(data);
+        let rom_entry_point = Self::extract_rom_entry_point(data);
         let nintendo_logo = Self::extract_nintendo_logo(data);
         let game_title = Self::extract_game_title(data);
         let game_code = Self::extract_game_code(data);
+        // --- Add ---
+        let marker_code = Self::extract_marker_code((data));
+
 
         verify_checksum(data).expect("Invalid checksum");
 
         Self {
-            entry_point,
+            rom_entry_point,
             nintendo_logo,
             game_title,
             game_code,
+            // --- Add ---
+            marker_code,
         }
     }
 
-    fn extract_entry_point(data: &[u8]) -> [u8; 4] {
+    // Address: 000h
+    // Bytes:   4
+    // Info:    32bit ARM branch opcode
+    fn extract_rom_entry_point(data: &[u8]) -> [u8; 4] {
         data[0x000..=0x003]
             .try_into()
-            .expect("extracting entry point")
+            .expect("extracting ROM entry point")
     }
 
+    // Address: 004h
+    // Bytes:   156
+    // Info:    compressed bitmap, required!
     fn extract_nintendo_logo(data: &[u8]) -> [u8; 156] {
         data[0x004..=0x09F]
             .try_into()
             .expect("extracting nintendo logo")
     }
 
+    // Address: 0A0h
+    // Bytes:   12
+    // Info:    uppercase ascii, max 12 characters
     fn extract_game_title(data: &[u8]) -> String {
         let game_title_bytes: [u8; 12] = data[0x0A0..=0x0AB]
             .try_into()
             .expect("extracting game title");
-        String::from_utf8(game_title_bytes.into()).expect("parsing game title")
+        
+        String::from_utf8(game_title_bytes.into())
+            .expect("parsing game title")
     }
 
+    // Address: 0ACh
+    // Bytes:   4
+    // Info:    uppercase ascii, 4 characters
     fn extract_game_code(data: &[u8]) -> String {
         let game_code_bytes: [u8; 4] = data[0x0AC..=0x0AF]
             .try_into()
             .expect("extracting game code");
-        String::from_utf8(game_code_bytes.into()).expect("parsing game code")
+        
+        String::from_utf8(game_code_bytes.into())
+            .expect("parsing game code")
     }
+
+    // --- Add ---
+
+    // Address: 0B0h
+    // Bytes:   2
+    // Info:    uppercase ascii, 2 characters
+    fn extract_marker_code(data: &[u8]) -> String {
+        let marker_code_bytes: [u8; 2] = data[0x0B0..=0x0B1]
+            .try_into()
+            .expect("extracting marker code");
+        
+        String::from_utf8(marker_code_bytes.into())
+            .expect("parsing marker code")
+    }
+
+    // Address: 0B2h
+    // Bytes:   1
+    // Info:    must be 96h, required!
+    fn extract_fixed_value(data: &[u8])s {
+        let marker_code_bytes: [u8; 2] = data[0x0B0..=0x0B1]
+            .try_into()
+            .expect("extracting marker code");
+        
+        String::from_utf8(marker_code_bytes.into())
+            .expect("parsing marker code")
+    }
+
 }
 
 fn verify_checksum(data: &[u8]) -> Result<(), ()> {

--- a/src/cartridge_header.rs
+++ b/src/cartridge_header.rs
@@ -1,5 +1,5 @@
 // Points to be clarified:
-// 1. Do we want to check that the value is correct in the appropriate functions? (e.g., extract_fixed_value)
+// 1. Do we want to check that the value of data[x..=y] is what we expect in the appropriate functions? (e.g., extract_fixed_value)
 // 2. BIOS must be able to overwrite the boot_mode header, as defined in the extract_boot_mode function comments; 
 // 3. BIOS must be able to overwrite the slave_id_number header, as defined in the extract_slave_id_number function comments; 
 // 4. If the GBA has been booted by using Joybus transfer mode, we have to put our initialization procedure directly at joybus_mode_entry_point address,

--- a/src/cartridge_header.rs
+++ b/src/cartridge_header.rs
@@ -84,18 +84,6 @@ impl CartridgeHeader {
             .expect("parsing marker code")
     }
 
-    // Address: 0B2h
-    // Bytes:   1
-    // Info:    must be 96h, required!
-    fn extract_fixed_value(data: &[u8])s {
-        let marker_code_bytes: [u8; 2] = data[0x0B0..=0x0B1]
-            .try_into()
-            .expect("extracting marker code");
-        
-        String::from_utf8(marker_code_bytes.into())
-            .expect("parsing marker code")
-    }
-
 }
 
 fn verify_checksum(data: &[u8]) -> Result<(), ()> {

--- a/src/cartridge_header.rs
+++ b/src/cartridge_header.rs
@@ -71,27 +71,21 @@ impl CartridgeHeader {
         }
     }
 
-    // Address: 000h
-    // Bytes:   4
-    // Info:    32bit ARM branch opcode, eg. "B rom_start"
+    // Info: 32bit ARM branch opcode, eg. "B rom_start"
     fn extract_rom_entry_point(data: &[u8]) -> [u8; 4] {
         data[0x000..=0x003]
             .try_into()
             .expect("extracting rom entry point")
     }
 
-    // Address: 004h
-    // Bytes:   156
-    // Info:    compressed bitmap, required!
+    // Info: compressed bitmap, required!
     fn extract_nintendo_logo(data: &[u8]) -> [u8; 156] {
         data[0x004..=0x09F]
             .try_into()
             .expect("extracting nintendo logo")
     }
 
-    // Address: 0A0h
-    // Bytes:   12
-    // Info:    uppercase ascii, max 12 characters
+    // Info: uppercase ascii, max 12 characters
     fn extract_game_title(data: &[u8]) -> String {
         let game_title_bytes: [u8; 12] = data[0x0A0..=0x0AB]
             .try_into()
@@ -101,9 +95,7 @@ impl CartridgeHeader {
             .expect("parsing game title")
     }
 
-    // Address: 0ACh
-    // Bytes:   4
-    // Info:    uppercase ascii, 4 characters
+    // Info: uppercase ascii, 4 characters
     fn extract_game_code(data: &[u8]) -> String {
         let game_code_bytes: [u8; 4] = data[0x0AC..=0x0AF]
             .try_into()
@@ -113,9 +105,8 @@ impl CartridgeHeader {
             .expect("parsing game code")
     }
 
-    // Address: 0B0h
-    // Bytes:   2
-    // Info:    uppercase ascii, 2 characters
+    
+    // Info: uppercase ascii, 2 characters
     fn extract_marker_code(data: &[u8]) -> String {
         let marker_code_bytes: [u8; 2] = data[0x0B0..=0x0B1]
             .try_into()
@@ -125,9 +116,7 @@ impl CartridgeHeader {
             .expect("parsing marker code")
     }
 
-    // Address: 0B2h
-    // Bytes:   1
-    // Info:    must be 96h, required!
+    // Info: must be 96h, required!
     fn extract_fixed_value(data: &[u8]) -> [u8; 1] {
         // TODO: Do we check if fixed_value header (data[0x0B2..=0x0B2]) is equals to 96h?
         data[0x0B2..=0x0B2]
@@ -135,9 +124,7 @@ impl CartridgeHeader {
             .expect("extracting fixed value")
     }
 
-    // Address: 0B3h
-    // Bytes:   1
-    // Info:    00h for current GBA models
+    // Info: 00h for current GBA models
     fn extract_main_unit_code(data: &[u8]) -> [u8; 1] {
         // TODO: Do we check if main_unit_code header (data[0x0B2..=0x0B2]) is equals to 00h?
         data[0x0B3..=0x0B3]
@@ -145,27 +132,22 @@ impl CartridgeHeader {
             .expect("extracting main unit code")
     }
 
-    // Address: 0B4h
-    // Bytes:   1
-    // Info:    usually 00h (bit7=DACS/debug related)
+    // Info: usually 00h (bit7=DACS/debug related)
     fn extract_device_type(data: &[u8]) -> [u8; 1] {
         data[0x0B4..=0x0B4]
             .try_into()
             .expect("extracting device type")
     }
 
-    // Address: 0B5h
-    // Bytes:   7
-    // Info:    should be zero filled
+    
+    // Info: should be zero filled
     fn extract_reserved_area_1(data: &[u8]) -> [u8; 7] {
         data[0x0B5..=0x0BB]
             .try_into()
             .expect("extracting reserved area 1")
     }
 
-    // Address: 0BCh
-    // Bytes:   1
-    // Info:    usually 00h
+    // Info: usually 00h
     fn extract_software_version(data: &[u8]) -> [u8; 1] {
         // TODO: Do we check if software_version header (data[0x0B2..=0x0B2]) is equals to 00h?
         data[0x0BC..=0x0BC]
@@ -173,9 +155,7 @@ impl CartridgeHeader {
             .expect("extracting software version")
     }
 
-    // Address: 0BDh
-    // Bytes:   1
-    // Info:    header checksum, required!
+    // Info: header checksum, required!
     fn extract_complement_check(data: &[u8]) -> [u8; 1] {
         // TODO: Do we check if extract_complement_check header (data[0x0BD..=0x0BD]) is correct?
         data[0x0BD..=0x0BD]
@@ -183,9 +163,7 @@ impl CartridgeHeader {
             .expect("extracting complement check")
     }
 
-    // Address: 0BEh
-    // Bytes:   2
-    // Info:    should be zero filled
+    // Info: should be zero filled
     fn extract_reserved_area_2(data: &[u8]) -> [u8; 2] {
         data[0x0BE..=0x0BF]
             .try_into()
@@ -194,9 +172,7 @@ impl CartridgeHeader {
 
     // --- Additional Multiboot Header Entries ---
 
-    // Address: 0C0h
-    // Bytes:   4
-    // Info:    32bit ARM branch opcode, eg. "B ram_start"
+    // Info: 32bit ARM branch opcode, eg. "B ram_start"
     fn extract_ram_entry_point(data: &[u8]) -> [u8; 4] {
         // This entry is used only if the GBA has been booted 
         // by using Normal or Multiplay transfer mode (but not by Joybus mode).
@@ -205,9 +181,7 @@ impl CartridgeHeader {
             .expect("extracting ram entry point")
     }
 
-    // Address: 0C4h 
-    // Bytes:   1
-    // Info:    init as 00h - BIOS overwrites this value!
+    // Info: init as 00h - BIOS overwrites this value!
     fn extract_boot_mode(data: &[u8]) -> [u8; 1] {
         // TODO: Do we check if boot_mode header (data[0x0C4..=0x0C4]) is equals to 00h?
 
@@ -224,9 +198,7 @@ impl CartridgeHeader {
             .expect("extracting boot mode")
     }
 
-    // Address: 0C5h
-    // Bytes:   1
-    // Info:    init as 00h - BIOS overwrites this value!
+    // Info: init as 00h - BIOS overwrites this value!
     fn extract_slave_id_number(data: &[u8]) -> [u8; 1] {
         // TODO: Do we check if slave_id_number header (data[0x0C5..=0x0C5]) is equals to 00h?
 
@@ -244,8 +216,6 @@ impl CartridgeHeader {
             .expect("extracting slave id number")
     }
 
-    // Address: 0C6h
-    // Bytes:   26
     // Info:    seems to be unused
     fn extract_not_used(data: &[u8]) -> [u8; 26] {
         data[0x0C6..=0x0DF]
@@ -253,8 +223,6 @@ impl CartridgeHeader {
             .expect("extracting not used")
     }
 
-    // Address: 0E0h
-    // Bytes:   4
     // Info:    32bit ARM branch opcode, eg. "B joy_start"
     fn extract_joybus_mode_entry_point(data: &[u8]) -> [u8; 4] {
         // If the GBA has been booted by using Joybus transfer mode, 

--- a/src/cartridge_header.rs
+++ b/src/cartridge_header.rs
@@ -71,21 +71,21 @@ impl CartridgeHeader {
         }
     }
 
-    // Info: 32bit ARM branch opcode, eg. "B rom_start"
+    // 32bit ARM branch opcode, eg. "B rom_start"
     fn extract_rom_entry_point(data: &[u8]) -> [u8; 4] {
         data[0x000..=0x003]
             .try_into()
             .expect("extracting rom entry point")
     }
 
-    // Info: compressed bitmap, required!
+    // compressed bitmap, required!
     fn extract_nintendo_logo(data: &[u8]) -> [u8; 156] {
         data[0x004..=0x09F]
             .try_into()
             .expect("extracting nintendo logo")
     }
 
-    // Info: uppercase ascii, max 12 characters
+    // uppercase ascii, max 12 characters
     fn extract_game_title(data: &[u8]) -> String {
         let game_title_bytes: [u8; 12] = data[0x0A0..=0x0AB]
             .try_into()
@@ -95,7 +95,7 @@ impl CartridgeHeader {
             .expect("parsing game title")
     }
 
-    // Info: uppercase ascii, 4 characters
+    // uppercase ascii, 4 characters
     fn extract_game_code(data: &[u8]) -> String {
         let game_code_bytes: [u8; 4] = data[0x0AC..=0x0AF]
             .try_into()
@@ -106,7 +106,7 @@ impl CartridgeHeader {
     }
 
     
-    // Info: uppercase ascii, 2 characters
+    // uppercase ascii, 2 characters
     fn extract_marker_code(data: &[u8]) -> String {
         let marker_code_bytes: [u8; 2] = data[0x0B0..=0x0B1]
             .try_into()
@@ -116,7 +116,7 @@ impl CartridgeHeader {
             .expect("parsing marker code")
     }
 
-    // Info: must be 96h, required!
+    // must be 96h, required!
     fn extract_fixed_value(data: &[u8]) -> [u8; 1] {
         // TODO: Do we check if fixed_value header (data[0x0B2..=0x0B2]) is equals to 96h?
         data[0x0B2..=0x0B2]
@@ -124,7 +124,7 @@ impl CartridgeHeader {
             .expect("extracting fixed value")
     }
 
-    // Info: 00h for current GBA models
+    // 00h for current GBA models
     fn extract_main_unit_code(data: &[u8]) -> [u8; 1] {
         // TODO: Do we check if main_unit_code header (data[0x0B2..=0x0B2]) is equals to 00h?
         data[0x0B3..=0x0B3]
@@ -132,7 +132,7 @@ impl CartridgeHeader {
             .expect("extracting main unit code")
     }
 
-    // Info: usually 00h (bit7=DACS/debug related)
+    // usually 00h (bit7=DACS/debug related)
     fn extract_device_type(data: &[u8]) -> [u8; 1] {
         data[0x0B4..=0x0B4]
             .try_into()
@@ -140,14 +140,14 @@ impl CartridgeHeader {
     }
 
     
-    // Info: should be zero filled
+    // should be zero filled
     fn extract_reserved_area_1(data: &[u8]) -> [u8; 7] {
         data[0x0B5..=0x0BB]
             .try_into()
             .expect("extracting reserved area 1")
     }
 
-    // Info: usually 00h
+    // usually 00h
     fn extract_software_version(data: &[u8]) -> [u8; 1] {
         // TODO: Do we check if software_version header (data[0x0B2..=0x0B2]) is equals to 00h?
         data[0x0BC..=0x0BC]
@@ -155,7 +155,7 @@ impl CartridgeHeader {
             .expect("extracting software version")
     }
 
-    // Info: header checksum, required!
+    // header checksum, required!
     fn extract_complement_check(data: &[u8]) -> [u8; 1] {
         // TODO: Do we check if extract_complement_check header (data[0x0BD..=0x0BD]) is correct?
         data[0x0BD..=0x0BD]
@@ -163,7 +163,7 @@ impl CartridgeHeader {
             .expect("extracting complement check")
     }
 
-    // Info: should be zero filled
+    // should be zero filled
     fn extract_reserved_area_2(data: &[u8]) -> [u8; 2] {
         data[0x0BE..=0x0BF]
             .try_into()
@@ -172,7 +172,7 @@ impl CartridgeHeader {
 
     // --- Additional Multiboot Header Entries ---
 
-    // Info: 32bit ARM branch opcode, eg. "B ram_start"
+    // 32bit ARM branch opcode, eg. "B ram_start"
     fn extract_ram_entry_point(data: &[u8]) -> [u8; 4] {
         // This entry is used only if the GBA has been booted 
         // by using Normal or Multiplay transfer mode (but not by Joybus mode).
@@ -181,7 +181,7 @@ impl CartridgeHeader {
             .expect("extracting ram entry point")
     }
 
-    // Info: init as 00h - BIOS overwrites this value!
+    // init as 00h - BIOS overwrites this value!
     fn extract_boot_mode(data: &[u8]) -> [u8; 1] {
         // TODO: Do we check if boot_mode header (data[0x0C4..=0x0C4]) is equals to 00h?
 
@@ -198,7 +198,7 @@ impl CartridgeHeader {
             .expect("extracting boot mode")
     }
 
-    // Info: init as 00h - BIOS overwrites this value!
+    // init as 00h - BIOS overwrites this value!
     fn extract_slave_id_number(data: &[u8]) -> [u8; 1] {
         // TODO: Do we check if slave_id_number header (data[0x0C5..=0x0C5]) is equals to 00h?
 
@@ -216,14 +216,14 @@ impl CartridgeHeader {
             .expect("extracting slave id number")
     }
 
-    // Info:    seems to be unused
+    // seems to be unused
     fn extract_not_used(data: &[u8]) -> [u8; 26] {
         data[0x0C6..=0x0DF]
             .try_into()
             .expect("extracting not used")
     }
 
-    // Info:    32bit ARM branch opcode, eg. "B joy_start"
+    // 32bit ARM branch opcode, eg. "B joy_start"
     fn extract_joybus_mode_entry_point(data: &[u8]) -> [u8; 4] {
         // If the GBA has been booted by using Joybus transfer mode, 
         // then the entry point is located at this address rather than at 20000C0h (ram_entry_point - data[0x0C0..=0x0C3]). 

--- a/src/cartridge_header.rs
+++ b/src/cartridge_header.rs
@@ -4,6 +4,11 @@ pub(crate) struct CartridgeHeader {
     pub(crate) game_title: String,
     pub(crate) game_code: String,
     pub(crate) marker_code: String,
+    pub(crate) fixed_value: [u8; 1],
+    pub(crate) main_unit_code: [u8; 1],
+    pub(crate) device_type: [u8; 1],
+    pub(crate) reserved_area: [u8; 1],
+    pub(crate) software_version: [u8; 1],
 }
 
 impl CartridgeHeader {
@@ -13,7 +18,12 @@ impl CartridgeHeader {
         let game_title = Self::extract_game_title(data);
         let game_code = Self::extract_game_code(data);
         // --- Add ---
-        let marker_code = Self::extract_marker_code((data));
+        let marker_code = Self::extract_marker_code(data);
+        let fixed_value = Self::extract_fixed_value(data);
+        let main_unit_code = Self::extract_main_unit_code(data);
+        let device_type = Self::extract_device_type(data);
+        let reserved_area = Self::extract_reserved_area(data);
+        let software_version = Self::extract_software_version(data);
 
 
         verify_checksum(data).expect("Invalid checksum");
@@ -25,6 +35,11 @@ impl CartridgeHeader {
             game_code,
             // --- Add ---
             marker_code,
+            fixed_value,
+            main_unit_code,
+            device_type,
+            reserved_area,
+            software_version,
         }
     }
 
@@ -83,6 +98,55 @@ impl CartridgeHeader {
         String::from_utf8(marker_code_bytes.into())
             .expect("parsing marker code")
     }
+
+    // Address: 0B2h
+    // Bytes:   1
+    // Info:    must be 96h, required!
+    fn extract_fixed_value(data: &[u8]) -> [u8; 1] {
+        // TODO: Do we check if data[0x0B2..=0x0B2] is equals to 96h?
+        data[0x0B2..=0x0B2]
+            .try_into()
+            .expect("extracting fixed value")
+    }
+
+    // Address: 0B3h
+    // Bytes:   1
+    // Info:    00h for current GBA models
+    fn extract_main_unit_code(data: &[u8]) -> [u8; 1] {
+        // TODO: Do we check if data[0x0B2..=0x0B2] is equals to 00h?
+        data[0x0B3..=0x0B4]
+            .try_into()
+            .expect("extracting main unit code")
+    }
+
+    // Address: 0B4h
+    // Bytes:   1
+    // Info:    usually 00h (bit7=DACS/debug related)
+    fn extract_device_type(data: &[u8]) -> [u8; 1] {
+        data[0x0B4..=0x0B5]
+            .try_into()
+            .expect("extracting device type")
+    }
+
+    // Address: 0B5h
+    // Bytes:   7
+    // Info:    should be zero filled
+    fn extract_reserved_area(data: &[u8]) -> [u8; 7] {
+        data[0x0B5..=0x0BB]
+            .try_into()
+            .expect("extracting reserved area")
+    }
+
+    // Address: 0BCh
+    // Bytes:   1
+    // Info:    usually 00h
+    fn extract_software_version(data: &[u8; 1]) -> [u8; 1] {
+        // TODO: Do we check if data[0x0B2..=0x0B2] is equals to 00h?
+        data[0x0BC..=0x0BC]
+            .try_into()
+            .expect("extracting software version")
+    }
+
 
 }
 

--- a/src/cartridge_header.rs
+++ b/src/cartridge_header.rs
@@ -1,8 +1,7 @@
 // Points to be clarified:
-// 1. Do we want to check that the value of data[x..=y] is what we expect in the appropriate functions? (e.g., extract_fixed_value)
-// 2. BIOS must be able to overwrite the boot_mode header, as defined in the extract_boot_mode function comments; 
-// 3. BIOS must be able to overwrite the slave_id_number header, as defined in the extract_slave_id_number function comments; 
-// 4. If the GBA has been booted by using Joybus transfer mode, we have to put our initialization procedure directly at joybus_mode_entry_point address,
+// 1. BIOS must be able to overwrite the boot_mode header, as defined in the extract_boot_mode function comments; 
+// 2. BIOS must be able to overwrite the slave_id_number header, as defined in the extract_slave_id_number function comments; 
+// 3. If the GBA has been booted by using Joybus transfer mode, we have to put our initialization procedure directly at joybus_mode_entry_point address,
 //    or redirect to the actual boot procedure by depositing a "B <start>" opcode in the space used by joybus_mode_entry_point.
 
 pub(crate) struct CartridgeHeader {
@@ -118,7 +117,6 @@ impl CartridgeHeader {
 
     // must be 96h, required!
     fn extract_fixed_value(data: &[u8]) -> [u8; 1] {
-        // TODO: Do we check if fixed_value header (data[0x0B2..=0x0B2]) is equals to 96h?
         data[0x0B2..=0x0B2]
             .try_into()
             .expect("extracting fixed value")
@@ -126,7 +124,6 @@ impl CartridgeHeader {
 
     // 00h for current GBA models
     fn extract_main_unit_code(data: &[u8]) -> [u8; 1] {
-        // TODO: Do we check if main_unit_code header (data[0x0B2..=0x0B2]) is equals to 00h?
         data[0x0B3..=0x0B3]
             .try_into()
             .expect("extracting main unit code")
@@ -149,7 +146,6 @@ impl CartridgeHeader {
 
     // usually 00h
     fn extract_software_version(data: &[u8]) -> [u8; 1] {
-        // TODO: Do we check if software_version header (data[0x0B2..=0x0B2]) is equals to 00h?
         data[0x0BC..=0x0BC]
             .try_into()
             .expect("extracting software version")
@@ -183,8 +179,6 @@ impl CartridgeHeader {
 
     // init as 00h - BIOS overwrites this value!
     fn extract_boot_mode(data: &[u8]) -> [u8; 1] {
-        // TODO: Do we check if boot_mode header (data[0x0C4..=0x0C4]) is equals to 00h?
-
         // The slave GBA download procedure overwrites this byte by a value which is indicating 
         // the used multiboot transfer mode.
         // Value  Expl.
@@ -200,8 +194,6 @@ impl CartridgeHeader {
 
     // init as 00h - BIOS overwrites this value!
     fn extract_slave_id_number(data: &[u8]) -> [u8; 1] {
-        // TODO: Do we check if slave_id_number header (data[0x0C5..=0x0C5]) is equals to 00h?
-
         // If the GBA has been booted in Normal or Multiplay mode, 
         // this byte becomes overwritten by the slave ID number of the local GBA
         // (that'd be always 01h for normal mode).


### PR DESCRIPTION
All the cartridge header implementations have been added to the `cartridge_headers.rs` file. (#17) 

Keep in mind:
`1.` BIOS must be able to overwrite the boot_mode header, as defined in the extract_boot_mode function comments; 
`2.` BIOS must be able to overwrite the slave_id_number header, as defined in the extract_slave_id_number function comments; 
`3.` If the GBA has been booted by using Joybus transfer mode, we have to put our initialization procedure directly at joybus_mode_entry_point address, or redirect to the actual boot procedure by depositing a "B <start>" opcode in the space used by joybus_mode_entry_point.