### PR TITLE
Add Data Processing (ALU) Core

### DIFF
--- a/src/alu_instruction.rs
+++ b/src/alu_instruction.rs
@@ -1,0 +1,43 @@
+pub(crate) enum ArmModeAluInstruction {
+    AND = 0x0,
+    EOR = 0x1,
+    SUB = 0x2,
+    RSB = 0x3,
+    ADD = 0x4,
+    ADC = 0x5,
+    SBC = 0x6,
+    RSC = 0x7,
+    TST = 0x8,
+    TEQ = 0x9,
+    CMP = 0xA,
+    CMN = 0xB,
+    ORR = 0xC,
+    MOV = 0xD,
+    BIC = 0xE,
+    MVN = 0xF,
+}
+
+impl From<u8> for ArmModeAluInstruction {
+    fn from(alu_opcode: u8) -> Self {
+        use ArmModeAluInstruction::*;
+        match alu_opcode {
+            0x0 => AND,
+            0x1 => EOR,
+            0x2 => SUB,
+            0x3 => RSB,
+            0x4 => ADD,
+            0x5 => ADC,
+            0x6 => SBC,
+            0x7 => RSC,
+            0x8 => TST,
+            0x9 => TEQ,
+            0xA => CMP,
+            0xB => CMN,
+            0xC => ORR,
+            0xD => MOV,
+            0xE => BIC,
+            0xF => MVN,
+            _ => unreachable!(),
+        }
+    }
+}

--- a/src/arm7tdmi.rs
+++ b/src/arm7tdmi.rs
@@ -159,13 +159,37 @@ impl Arm7tdmi {
                                 }
                                 _ => unreachable!(),
                             },
-                            is => op2 <<= is,
+
+                            is => {
+                                match shift_type {
+                                    // Logical Shift Left
+                                    0 => op2 <<= is,
+                                    // Logical Shift Right
+                                    1 => op2 >>= is,
+                                    // Arithmetic Shift Right
+                                    2 => op2 = ((op2 as i32) >> is) as u32, // TODO: Review rust arithmetic shift right
+                                    // Rotate Right
+                                    3 => op2 = op2.rotate_right(is as u32),
+                                    _ => unreachable!(),
+                                }
+                            }
                         };
                     }
                     /// Shift by register
                     1 => {
                         let rs = ((op_code & 0x00_00_0F_00) >> 8) as u8;
-                        op2 <<= self.registers[rs as usize] & 0x00_00_00_FF;
+                        let shift_value = self.registers[rs as usize] & 0x00_00_00_FF;
+                        match shift_type {
+                            // Logical Shift Left
+                            0 => op2 <<= shift_value,
+                            // Logical Shift Right
+                            1 => op2 >>= shift_value,
+                            // Arithmetic Shift Right
+                            2 => op2 = ((op2 as i32) >> shift_value) as u32, // TODO: Review rust arithmetic shift right
+                            // Rotate Right
+                            3 => op2 = op2.rotate_right(shift_value as u32),
+                            _ => unreachable!(),
+                        };
                     }
                     _ => unreachable!(),
                 };

--- a/src/arm7tdmi.rs
+++ b/src/arm7tdmi.rs
@@ -96,13 +96,13 @@ impl Arm7tdmi {
     }
 
     fn data_processing(&mut self, op_code: u32) {
-        /// bit [25] is I = Immediate Flag
+        // bit [25] is I = Immediate Flag
         let i = ((op_code & 0x02_00_00_00) >> 25) as u8;
-        /// bit [24-21]
+        // bits [24-21]
         let alu_opcode = ((op_code & 0x01_E0_00_00) >> 25) as u8;
-        /// bit [20] is sets condition codes
+        // bit [20] is sets condition codes
         let s = ((op_code & 0x00_10_00_00) >> 20) as u8;
-        /// bits [15-12] are the Rd
+        // bits [15-12] are the Rd
         let rd = ((op_code & 0x00_00_F0_00) >> 12) as u8;
 
         let op2 = match i {
@@ -174,9 +174,9 @@ impl Arm7tdmi {
             }
             /// Immediate as 2nd Operand
             1 => {
-                /// bits [11-8] are ROR-Shift applied to nn
+                // bits [11-8] are ROR-Shift applied to nn
                 let is = op_code & 0x00_00_0F_00;
-                /// bits [7-0] are the immediate value
+                // bits [7-0] are the immediate value
                 let nn = op_code & 0x00_00_00_FF;
 
                 // I'm not sure about `* 2`

--- a/src/arm7tdmi.rs
+++ b/src/arm7tdmi.rs
@@ -1,5 +1,6 @@
 use std::{convert::TryInto, fmt::Debug};
 
+use crate::alu_instruction::ArmModeAluInstruction;
 use crate::instruction::ArmModeInstruction;
 use crate::{condition::Condition, cpsr::Cpsr, cpu::Cpu};
 
@@ -55,8 +56,8 @@ impl Cpu for Arm7tdmi {
             BranchLink => {
                 self.branch_link(op_code);
             }
-            Mov => {
-                todo!("Remove move, use data_processing instruction as a type");
+            DataProcessing1 | DataProcessing2 | DataProcessing3 => {
+                self.data_processing(op_code);
             }
             _ => todo!("Instruction not implemented yet."),
         }
@@ -184,12 +185,11 @@ impl Arm7tdmi {
             _ => unreachable!(),
         };
 
-        todo!("Match the ALU instruction and execute");
-        // Example:
-        // match alu_opcode.into() {
-        //     Mov => self.mov(rd, op2),
-        //     ...
-        // }
+        use ArmModeAluInstruction::*;
+        match ArmModeAluInstruction::from(alu_opcode) {
+            Mov => self.mov(rd as usize, op2),
+            _ => todo!(),
+        }
 
         todo!("Returned CPSR flags");
     }

--- a/src/arm7tdmi.rs
+++ b/src/arm7tdmi.rs
@@ -1,5 +1,6 @@
 use std::{convert::TryInto, fmt::Debug};
 
+use crate::instruction::ArmModeInstruction;
 use crate::{condition::Condition, cpsr::Cpsr, cpu::Cpu};
 
 pub(crate) struct Arm7tdmi {
@@ -123,52 +124,9 @@ impl Arm7tdmi {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
-pub(crate) enum ArmModeInstruction {
-    Branch = 0x0A_00_00_00,
-    BranchLink = 0x0B_00_00_00,
-
-    /// 27-26 must be 0b00
-    /// 24-21 must be 0b1101
-    /// 19-16 must be 0b0000
-    Mov = 0x01_A0_00_00,
-}
-
-impl TryFrom<u32> for ArmModeInstruction {
-    type Error = String;
-
-    fn try_from(op_code: u32) -> Result<Self, Self::Error> {
-        use ArmModeInstruction::*;
-
-        if Self::check(Branch, op_code) {
-            Ok(Branch)
-        } else if Self::check(BranchLink, op_code) {
-            Ok(BranchLink)
-        } else if Self::check(Mov, op_code) {
-            Ok(Mov)
-        } else {
-            Err("instruction not implemented :(.".to_owned())
-        }
-    }
-}
-
-impl ArmModeInstruction {
-    fn check(instruction_type: ArmModeInstruction, op_code: u32) -> bool {
-        (Self::get_mask(&instruction_type) & op_code) == instruction_type as u32
-    }
-
-    fn get_mask(instruction_type: &ArmModeInstruction) -> u32 {
-        use ArmModeInstruction::*;
-
-        match instruction_type {
-            Branch | BranchLink => 0x0F_00_00_00,
-            Mov => 0x0D_EF_00_00,
-            _ => todo!(),
-        }
-    }
-}
 #[cfg(test)]
 mod tests {
+    use crate::instruction::ArmModeInstruction;
     use pretty_assertions::assert_eq;
 
     use super::*;

--- a/src/cpsr.rs
+++ b/src/cpsr.rs
@@ -18,6 +18,14 @@ impl Cpsr {
         self.0 & 0x8000 != 0
     }
 
+    pub(crate) fn set_signed(&mut self) {
+        self.0 |= 0b1000_0000_0000_0000_0000_0000_0000_0000;
+    }
+
+    pub(crate) fn set_not_signed(&mut self) {
+        self.0 &= 0b0111_1111_1111_1111_1111_1111_1111_1111;
+    }
+
     fn overflow(&self) -> bool {
         self.0 & 0x1000 != 0
     }

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -1,12 +1,10 @@
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum ArmModeInstruction {
+    DataProcessing1 = 0x00_00_00_00,
+    DataProcessing2 = 0x00_00_00_10,
+    DataProcessing3 = 0x02_00_00_10,
     Branch = 0x0A_00_00_00,
     BranchLink = 0x0B_00_00_00,
-
-    /// 27-26 must be 0b00
-    /// 24-21 must be 0b1101
-    /// 19-16 must be 0b0000
-    Mov = 0x01_A0_00_00,
 }
 
 impl TryFrom<u32> for ArmModeInstruction {
@@ -15,12 +13,16 @@ impl TryFrom<u32> for ArmModeInstruction {
     fn try_from(op_code: u32) -> Result<Self, Self::Error> {
         use ArmModeInstruction::*;
 
-        if Self::check(Branch, op_code) {
+        if Self::check(DataProcessing1, op_code) {
+            Ok(DataProcessing1)
+        } else if Self::check(DataProcessing2, op_code) {
+            Ok(DataProcessing2)
+        } else if Self::check(DataProcessing3, op_code) {
+            Ok(DataProcessing3)
+        } else if Self::check(Branch, op_code) {
             Ok(Branch)
         } else if Self::check(BranchLink, op_code) {
             Ok(BranchLink)
-        } else if Self::check(Mov, op_code) {
-            Ok(Mov)
         } else {
             Err("instruction not implemented :(.".to_owned())
         }
@@ -37,7 +39,8 @@ impl ArmModeInstruction {
 
         match instruction_type {
             Branch | BranchLink => 0x0F_00_00_00,
-            Mov => 0x0D_EF_00_00,
+            DataProcessing1 | DataProcessing2 => 0x0E_00_00_10,
+            DataProcessing3 => 0x0E_00_00_00,
             _ => todo!(),
         }
     }

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -2,7 +2,7 @@
 pub(crate) enum ArmModeInstruction {
     DataProcessing1 = 0x00_00_00_00,
     DataProcessing2 = 0x00_00_00_10,
-    DataProcessing3 = 0x02_00_00_10,
+    DataProcessing3 = 0x02_00_00_00,
     Branch = 0x0A_00_00_00,
     BranchLink = 0x0B_00_00_00,
 }

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -1,0 +1,44 @@
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ArmModeInstruction {
+    Branch = 0x0A_00_00_00,
+    BranchLink = 0x0B_00_00_00,
+
+    /// 27-26 must be 0b00
+    /// 24-21 must be 0b1101
+    /// 19-16 must be 0b0000
+    Mov = 0x01_A0_00_00,
+}
+
+impl TryFrom<u32> for ArmModeInstruction {
+    type Error = String;
+
+    fn try_from(op_code: u32) -> Result<Self, Self::Error> {
+        use ArmModeInstruction::*;
+
+        if Self::check(Branch, op_code) {
+            Ok(Branch)
+        } else if Self::check(BranchLink, op_code) {
+            Ok(BranchLink)
+        } else if Self::check(Mov, op_code) {
+            Ok(Mov)
+        } else {
+            Err("instruction not implemented :(.".to_owned())
+        }
+    }
+}
+
+impl ArmModeInstruction {
+    fn check(instruction_type: ArmModeInstruction, op_code: u32) -> bool {
+        (Self::get_mask(&instruction_type) & op_code) == instruction_type as u32
+    }
+
+    fn get_mask(instruction_type: &ArmModeInstruction) -> u32 {
+        use ArmModeInstruction::*;
+
+        match instruction_type {
+            Branch | BranchLink => 0x0F_00_00_00,
+            Mov => 0x0D_EF_00_00,
+            _ => todo!(),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod cartridge_header;
 mod condition;
 mod cpsr;
 mod cpu;
+mod instruction;
 
 fn main() {
     println!("clementine v0.1.0");

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use cartridge_header::CartridgeHeader;
 
 use crate::{arm7tdmi::Arm7tdmi, cpu::Cpu};
 
+mod alu_instruction;
 mod arm7tdmi;
 mod cartridge_header;
 mod condition;


### PR DESCRIPTION
I implemented [this](https://rust-console.github.io/gbatek-gbaonly/#--arm-opcodes-data-processing-alu) (the chunk with ">" on the left)
```
  Bit    Expl.
  31-28  Condition
  27-26  Must be 00b for this instruction
  25     I - Immediate 2nd Operand Flag (0=Register, 1=Immediate)
  24-21  Opcode (0-Fh)               ;*=Arithmetic, otherwise Logical
           0: AND{cond}{S} Rd,Rn,Op2    ;AND logical       Rd = Rn AND Op2
           1: EOR{cond}{S} Rd,Rn,Op2    ;XOR logical       Rd = Rn XOR Op2
           2: SUB{cond}{S} Rd,Rn,Op2 ;* ;subtract          Rd = Rn-Op2
           3: RSB{cond}{S} Rd,Rn,Op2 ;* ;subtract reversed Rd = Op2-Rn
           4: ADD{cond}{S} Rd,Rn,Op2 ;* ;add               Rd = Rn+Op2
           5: ADC{cond}{S} Rd,Rn,Op2 ;* ;add with carry    Rd = Rn+Op2+Cy
           6: SBC{cond}{S} Rd,Rn,Op2 ;* ;sub with carry    Rd = Rn-Op2+Cy-1
           7: RSC{cond}{S} Rd,Rn,Op2 ;* ;sub cy. reversed  Rd = Op2-Rn+Cy-1
           8: TST{cond}{P}    Rn,Op2    ;test            Void = Rn AND Op2
           9: TEQ{cond}{P}    Rn,Op2    ;test exclusive  Void = Rn XOR Op2
           A: CMP{cond}{P}    Rn,Op2 ;* ;compare         Void = Rn-Op2
           B: CMN{cond}{P}    Rn,Op2 ;* ;compare neg.    Void = Rn+Op2
           C: ORR{cond}{S} Rd,Rn,Op2    ;OR logical        Rd = Rn OR Op2
           D: MOV{cond}{S} Rd,Op2       ;move              Rd = Op2
           E: BIC{cond}{S} Rd,Rn,Op2    ;bit clear         Rd = Rn AND NOT Op2
           F: MVN{cond}{S} Rd,Op2       ;not               Rd = NOT Op2

>   20     S - Set Condition Codes (0=No, 1=Yes) (Must be 1 for opcode 8-B)
>   19-16  Rn - 1st Operand Register (R0..R15) (including PC=R15)
>               Must be 0000b for MOV/MVN.
>   15-12  Rd - Destination Register (R0..R15) (including PC=R15)
>               Must be 0000b (or 1111b) for CMP/CMN/TST/TEQ{P}.
>   When above Bit 25 I=0 (Register as 2nd Operand)
>     When below Bit 4 R=0 - Shift by Immediate
>       11-7   Is - Shift amount   (1-31, 0=Special/See below)
>     When below Bit 4 R=1 - Shift by Register
>       11-8   Rs - Shift register (R0-R14) - only lower 8bit 0-255 used
>       7      Reserved, must be zero  (otherwise multiply or undefined opcode)
>     6-5    Shift Type (0=LSL, 1=LSR, 2=ASR, 3=ROR)
>     4      R - Shift by Register Flag (0=Immediate, 1=Register)
>     3-0    Rm - 2nd Operand Register (R0..R15) (including PC=R15)
>   When above Bit 25 I=1 (Immediate as 2nd Operand)
>     11-8   Is - ROR-Shift applied to nn (0-30, in steps of 2)
>     7-0    nn - 2nd Operand Unsigned 8bit Immediate

```