### PR TITLE
Add bit manipulation methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,7 @@ dependencies = [
  "egui_glium",
  "glium",
  "pretty_assertions",
+ "rand",
 ]
 
 [[package]]
@@ -1178,6 +1179,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
 name = "pretty_assertions"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1216,6 +1223,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ glium = "0.32"
 
 [dev-dependencies]
 pretty_assertions = "1.3.0"
+rand = "0.8.5"

--- a/src/bitwise.rs
+++ b/src/bitwise.rs
@@ -1,0 +1,156 @@
+/// Contains some helper methods to manipulate bits,
+/// the index (`bit_idk`) is supposed to be from lsb to msb (right to left)
+pub(crate) trait Bits {
+    fn is_bit_on(self, bit_idx: u8) -> bool;
+    fn is_bit_off(self, bit_idx: u8) -> bool;
+    fn set_bit_on(&mut self, bit_idx: u8);
+    fn set_bit_off(&mut self, bit_idx: u8);
+    fn toggle_bit(&mut self, bit_idx: u8);
+    fn set_bit(&mut self, bit_idx: u8, value: u8);
+    fn get_bit(self, bit_idx: u8) -> u8;
+}
+
+impl Bits for u32 {
+    fn is_bit_on(self, bit_idx: u8) -> bool {
+        debug_assert!(bit_idx < 32);
+
+        let mask = 0b1 << bit_idx;
+        (self & mask) != 0
+    }
+
+    fn is_bit_off(self, bit_idx: u8) -> bool {
+        debug_assert!(bit_idx < 32);
+
+        let mask = 0b1 << bit_idx;
+        (self & mask) == 0
+    }
+
+    fn set_bit_on(&mut self, bit_idx: u8) {
+        debug_assert!(bit_idx < 32);
+
+        let mask = 0b1 << bit_idx;
+        *self |= mask;
+    }
+
+    fn set_bit_off(&mut self, bit_idx: u8) {
+        debug_assert!(bit_idx < 32);
+
+        let mask = !(0b1 << bit_idx);
+        *self &= mask;
+    }
+
+    /// Switches from 1 to 0, or conversely from 0 to 1
+    fn toggle_bit(&mut self, bit_idx: u8) {
+        debug_assert!(bit_idx < 32);
+
+        let mask = 0b1 << bit_idx;
+        *self ^= mask;
+    }
+
+    fn set_bit(&mut self, bit_idx: u8, value: u8) {
+        match value {
+            0 => self.set_bit_off(bit_idx),
+            1 => self.set_bit_on(bit_idx),
+            _ => panic!(),
+        }
+    }
+
+    fn get_bit(self, bit_idx: u8) -> u8 {
+        match self.is_bit_on(bit_idx) {
+            true => 1,
+            false => 0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::Rng;
+
+    #[test]
+    fn test_is_on() {
+        let b = 0b110011101_u32;
+        assert!(b.is_bit_on(0));
+        assert!(!b.is_bit_on(1));
+        assert!(b.is_bit_on(2));
+        assert!(b.is_bit_on(3));
+        assert!(b.is_bit_on(8));
+        assert!(!b.is_bit_on(31));
+    }
+
+    #[test]
+    fn test_is_off() {
+        let b = 0b110011101_u32;
+        assert!(!b.is_bit_off(0));
+        assert!(b.is_bit_off(1));
+        assert!(!b.is_bit_off(2));
+        assert!(!b.is_bit_off(3));
+        assert!(!b.is_bit_off(8));
+        assert!(b.is_bit_off(31));
+    }
+
+    #[test]
+    fn test_set_on() {
+        let mut b = 0b110011101_u32;
+        b.set_bit_on(1);
+        b.set_bit_on(0);
+        b.set_bit_on(11);
+        assert_eq!(b, 0b100110011111);
+    }
+
+    #[test]
+    fn test_set_off() {
+        let mut b = 0b1101001101_u32;
+        b.set_bit_off(0);
+        b.set_bit_off(4);
+        b.set_bit_off(5);
+        b.set_bit_off(6);
+        b.set_bit_off(20);
+        assert_eq!(b, 0b1100001100);
+    }
+
+    #[test]
+    fn toggle_bit() {
+        let original = rand::thread_rng().gen_range(1..=u32::MAX - 1);
+        let mut fin = original;
+        for i in 0..32 {
+            fin.toggle_bit(i)
+        }
+
+        assert_eq!(!original, fin);
+    }
+
+    #[test]
+    fn set_bit() {
+        let mut b = 0b1100110_u32;
+        b.set_bit(0, 1);
+        b.set_bit(1, 1);
+        b.set_bit(2, 0);
+        b.set_bit(3, 0);
+        assert_eq!(b, 0b1100011)
+    }
+
+    #[test]
+    fn get_bit() {
+        let b = 0b1011001110_u32;
+        assert_eq!(b.get_bit(0), 0);
+        assert_eq!(b.get_bit(1), 1);
+        assert_eq!(b.get_bit(2), 1);
+        assert_eq!(b.get_bit(31), 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn invalid_index() {
+        let b = 0u32;
+        b.is_bit_on(32);
+    }
+
+    #[test]
+    #[should_panic]
+    fn invalid_set() {
+        let mut b = 0u32;
+        b.set_bit(0, 2);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use crate::{arm7tdmi::Arm7tdmi, cpu::Cpu, egui_app::EguiApp};
 
 mod alu_instruction;
 mod arm7tdmi;
+mod bitwise;
 mod cartridge_header;
 mod condition;
 mod cpsr;


### PR DESCRIPTION
It adds some methods to check and set single bits. For now there aren't methods to handle multiple bits masks, and it's limited to u32 (due to the assence of a common Integer trait  in rust).

Refers to #33 