### PR TITLE
ARM: Implement `teq` `ALU` instruction

### DIFF
--- a/src/arm7tdmi.rs
+++ b/src/arm7tdmi.rs
@@ -1,6 +1,7 @@
 use std::convert::TryInto;
 
 use crate::alu_instruction::ArmModeAluInstruction;
+use crate::bitwise::Bits;
 use crate::instruction::ArmModeInstruction;
 use crate::{condition::Condition, cpsr::Cpsr, cpu::Cpu};
 
@@ -141,12 +142,7 @@ impl Arm7tdmi {
                                 1 => {
                                     // TODO: It's better to implement the logical instruction in order to execute directly LSR#0?
                                     let rm = self.registers[op2 as usize];
-                                    match (rm & 0b1000_0000_0000_0000_0000_0000_0000_0000) >> 31 {
-                                        1 => self.cpsr.set_signed(),
-                                        0 => self.cpsr.set_not_signed(),
-                                        _ => unreachable!(),
-                                    }
-
+                                    self.cpsr.set_signed(rm.get_bit(31));
                                     op2 = 0;
                                 }
                                 // ASR#0: Interpreted as ASR#32, ie. Op2 and C are filled by Bit 31 of Rm.
@@ -156,11 +152,11 @@ impl Arm7tdmi {
                                     match (rm & 0b1000_0000_0000_0000_0000_0000_0000_0000) >> 31 {
                                         1 => {
                                             op2 = 1;
-                                            self.cpsr.set_signed()
+                                            self.cpsr.set_signed(true)
                                         }
                                         0 => {
                                             op2 = 0;
-                                            self.cpsr.set_not_signed()
+                                            self.cpsr.set_signed(true)
                                         }
                                         _ => unreachable!(),
                                     }

--- a/src/bitwise.rs
+++ b/src/bitwise.rs
@@ -6,8 +6,8 @@ pub(crate) trait Bits {
     fn set_bit_on(&mut self, bit_idx: u8);
     fn set_bit_off(&mut self, bit_idx: u8);
     fn toggle_bit(&mut self, bit_idx: u8);
-    fn set_bit(&mut self, bit_idx: u8, value: u8);
-    fn get_bit(self, bit_idx: u8) -> u8;
+    fn set_bit(&mut self, bit_idx: u8, value: bool);
+    fn get_bit(self, bit_idx: u8) -> bool;
 }
 
 impl Bits for u32 {
@@ -47,19 +47,15 @@ impl Bits for u32 {
         *self ^= mask;
     }
 
-    fn set_bit(&mut self, bit_idx: u8, value: u8) {
+    fn set_bit(&mut self, bit_idx: u8, value: bool) {
         match value {
-            0 => self.set_bit_off(bit_idx),
-            1 => self.set_bit_on(bit_idx),
-            _ => panic!(),
+            false => self.set_bit_off(bit_idx),
+            true => self.set_bit_on(bit_idx),
         }
     }
 
-    fn get_bit(self, bit_idx: u8) -> u8 {
-        match self.is_bit_on(bit_idx) {
-            true => 1,
-            false => 0,
-        }
+    fn get_bit(self, bit_idx: u8) -> bool {
+        self.is_bit_on(bit_idx)
     }
 }
 
@@ -124,20 +120,20 @@ mod tests {
     #[test]
     fn set_bit() {
         let mut b = 0b1100110_u32;
-        b.set_bit(0, 1);
-        b.set_bit(1, 1);
-        b.set_bit(2, 0);
-        b.set_bit(3, 0);
+        b.set_bit(0, true);
+        b.set_bit(1, true);
+        b.set_bit(2, false);
+        b.set_bit(3, false);
         assert_eq!(b, 0b1100011)
     }
 
     #[test]
     fn get_bit() {
         let b = 0b1011001110_u32;
-        assert_eq!(b.get_bit(0), 0);
-        assert_eq!(b.get_bit(1), 1);
-        assert_eq!(b.get_bit(2), 1);
-        assert_eq!(b.get_bit(31), 0);
+        assert!(b.get_bit(1));
+        assert!(!b.get_bit(0));
+        assert!(b.get_bit(2));
+        assert!(!b.get_bit(31));
     }
 
     #[test]
@@ -145,12 +141,5 @@ mod tests {
     fn invalid_index() {
         let b = 0u32;
         b.is_bit_on(32);
-    }
-
-    #[test]
-    #[should_panic]
-    fn invalid_set() {
-        let mut b = 0u32;
-        b.set_bit(0, 2);
     }
 }

--- a/src/cpsr.rs
+++ b/src/cpsr.rs
@@ -1,4 +1,4 @@
-use crate::condition::Condition;
+use crate::{bitwise::Bits, condition::Condition};
 
 /// Current Program Status Register.
 #[derive(Default)]
@@ -15,15 +15,11 @@ impl Cpsr {
     }
 
     fn signed(&self) -> bool {
-        self.0 & 0b1000_0000_0000_0000_0000_0000_0000_0000 != 0
+        self.0.get_bit(31)
     }
 
-    pub(crate) fn set_signed(&mut self) {
-        self.0 |= 0b1000_0000_0000_0000_0000_0000_0000_0000;
-    }
-
-    pub(crate) fn set_not_signed(&mut self) {
-        self.0 &= 0b0111_1111_1111_1111_1111_1111_1111_1111;
+    pub(crate) fn set_signed(&mut self, value: bool) {
+        self.0.set_bit(31, value)
     }
 
     fn overflow(&self) -> bool {
@@ -38,7 +34,7 @@ mod tests {
     #[test]
     fn check_sign_flag() {
         let mut cpsr: Cpsr = Cpsr(0);
-        cpsr.set_signed();
+        cpsr.set_signed(true);
         assert!(cpsr.signed());
     }
 

--- a/src/cpsr.rs
+++ b/src/cpsr.rs
@@ -14,12 +14,21 @@ impl Cpsr {
         }
     }
 
-    fn signed(&self) -> bool {
+    pub(crate) fn signed(&self) -> bool {
         self.0.get_bit(31)
     }
 
     pub(crate) fn set_signed(&mut self, value: bool) {
         self.0.set_bit(31, value)
+    }
+
+    #[cfg(test)] // TODO: remove cfg when this API will be used at least one in prod code.
+    pub(crate) fn zero_flag(&self) -> bool {
+        self.0.get_bit(30)
+    }
+
+    pub(crate) fn set_zero_flag(&mut self, value: bool) {
+        self.0.set_bit(30, value)
     }
 
     fn overflow(&self) -> bool {


### PR DESCRIPTION
This don't cover all case because we are not taking care of changing all CPU register and other marginal stuff,
but it's a start :).

Signed-off-by: Federico Guerinoni <guerinoni.federico@gmail.com>
