### PR TITLE
CI: Enable more pedantic warnings on clippy

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,4 +38,4 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Lint
-      run: cargo clippy -- -D warnings
+      run: cargo clippy -- -D warnings -W clippy::complexity -W clippy::correctness -W clippy::nursery -W clippy::perf -W clippy::style -W clippy::suspicious

--- a/src/alu_instruction.rs
+++ b/src/alu_instruction.rs
@@ -1,4 +1,4 @@
-pub(crate) enum ArmModeAluInstruction {
+pub enum ArmModeAluInstruction {
     And = 0x0,
     Eor = 0x1,
     Sub = 0x2,

--- a/src/arm7tdmi.rs
+++ b/src/arm7tdmi.rs
@@ -5,7 +5,7 @@ use crate::bitwise::Bits;
 use crate::instruction::ArmModeInstruction;
 use crate::{condition::Condition, cpsr::Cpsr, cpu::Cpu};
 
-pub(crate) struct Arm7tdmi {
+pub struct Arm7tdmi {
     rom: Vec<u8>,
 
     registers: [u32; 16],

--- a/src/bitwise.rs
+++ b/src/bitwise.rs
@@ -1,6 +1,6 @@
 /// Contains some helper methods to manipulate bits,
 /// the index (`bit_idk`) is supposed to be from lsb to msb (right to left)
-pub(crate) trait Bits {
+pub trait Bits {
     fn is_bit_on(&self, bit_idx: u8) -> bool;
     fn is_bit_off(&self, bit_idx: u8) -> bool;
     fn set_bit_on(&mut self, bit_idx: u8);

--- a/src/cartridge_header.rs
+++ b/src/cartridge_header.rs
@@ -1,5 +1,5 @@
 #[allow(dead_code)] // FIXME: remove this `allow` when all member are used.
-pub(crate) struct CartridgeHeader {
+pub struct CartridgeHeader {
     pub(crate) rom_entry_point: [u8; 4],
     pub(crate) nintendo_logo: [u8; 156],
     pub(crate) game_title: String,

--- a/src/condition.rs
+++ b/src/condition.rs
@@ -1,5 +1,5 @@
 /// Arm opcode condition.
-pub(crate) enum Condition {
+pub enum Condition {
     EQ = 0x0,
     NE = 0x1,
     CS = 0x2,

--- a/src/cpsr.rs
+++ b/src/cpsr.rs
@@ -4,7 +4,7 @@ use crate::{bitwise::Bits, condition::Condition};
 
 /// Current Program Status Register.
 #[derive(Default)]
-pub(crate) struct Cpsr(u32);
+pub struct Cpsr(u32);
 
 impl Cpsr {
     pub(crate) fn can_execute(&self, cond: Condition) -> bool {
@@ -111,7 +111,7 @@ impl Cpsr {
         self.0.set_bit(29, value);
     }
 
-    #[cfg(test)] // TODO: remove cfg when this API will be used at least one in prod code.
+    #[allow(dead_code)] // TODO: remove allow when this API will be used at least one in prod code.
     pub fn set_overflow_flag(&mut self, value: bool) {
         self.0.set_bit(28, value);
     }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1,6 +1,6 @@
 use crate::condition::Condition;
 
-pub(crate) trait Cpu {
+pub trait Cpu {
     /// Size of Opcode: it can be changed
     type OpCodeType;
     type InstructionType;

--- a/src/egui_app.rs
+++ b/src/egui_app.rs
@@ -8,7 +8,7 @@ use crate::{
     ppu::{DISPLAY_HEIGHT, DISPLAY_WIDTH},
 };
 
-pub(crate) struct EguiApp<T>
+pub struct EguiApp<T>
 where
     T: Cpu,
 {
@@ -60,7 +60,7 @@ where
     }
 }
 
-pub(crate) struct Gba<T>
+pub struct Gba<T>
 where
     T: Cpu,
 {
@@ -71,7 +71,7 @@ impl<T> Gba<T>
 where
     T: Cpu,
 {
-    pub(crate) fn new(cpu: T) -> Self {
+    pub(crate) const fn new(cpu: T) -> Self {
         Self { cpu }
     }
 }

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -1,5 +1,5 @@
 #[derive(Debug, PartialEq, Eq)]
-pub(crate) enum ArmModeInstruction {
+pub enum ArmModeInstruction {
     DataProcessing1 = 0b0000_0000_0000_0000_0000_0000_0000_0000,
     DataProcessing2 = 0b0000_0000_0000_0000_0000_0000_0001_0000,
     DataProcessing3 = 0b0000_0010_0000_0000_0000_0000_0000_0000,
@@ -30,11 +30,11 @@ impl TryFrom<u32> for ArmModeInstruction {
 }
 
 impl ArmModeInstruction {
-    fn check(instruction_type: ArmModeInstruction, op_code: u32) -> bool {
+    const fn check(instruction_type: Self, op_code: u32) -> bool {
         (Self::get_mask(&instruction_type) & op_code) == instruction_type as u32
     }
 
-    fn get_mask(instruction_type: &ArmModeInstruction) -> u32 {
+    const fn get_mask(instruction_type: &Self) -> u32 {
         use ArmModeInstruction::*;
 
         match instruction_type {

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -1,2 +1,2 @@
-pub(crate) const DISPLAY_WIDTH: usize = 240;
-pub(crate) const DISPLAY_HEIGHT: usize = 160;
+pub const DISPLAY_WIDTH: usize = 240;
+pub const DISPLAY_HEIGHT: usize = 160;


### PR DESCRIPTION
In the near future we can shortcut this long command with `make` or `just`.
Another improvements is enable all warnings, but is a long run :)