### PR TITLE
ARM: Implement `TransImm9` a DataTransfer case

### DIFF
--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -5,6 +5,7 @@ pub enum ArmModeInstruction {
     DataProcessing3 = 0b0000_0010_0000_0000_0000_0000_0000_0000,
     Branch = 0b0000_1010_0000_0000_0000_0000_0000_0000,
     BranchLink = 0b0000_1011_0000_0000_0000_0000_0000_0000,
+    DataTransfer = 0b0000_0100_0000_0000_0000_0000_0000_0000,
 }
 
 impl TryFrom<u32> for ArmModeInstruction {
@@ -23,6 +24,8 @@ impl TryFrom<u32> for ArmModeInstruction {
             Ok(Branch)
         } else if Self::check(BranchLink, op_code) {
             Ok(BranchLink)
+        } else if Self::check(DataTransfer, op_code) {
+            Ok(DataTransfer)
         } else {
             Err("instruction not implemented :(.".to_owned())
         }
@@ -41,6 +44,7 @@ impl ArmModeInstruction {
             Branch | BranchLink => 0b0000_1111_0000_0000_0000_0000_0000_0000,
             DataProcessing1 | DataProcessing2 => 0b0000_1110_0000_0000_0000_0000_0001_0000,
             DataProcessing3 => 0b0000_1110_0000_0000_0000_0000_0000_0000,
+            DataTransfer => 0b0000_1100_0000_0000_0000_0000_0000_0000,
         }
     }
 }


### PR DESCRIPTION
Now we have one of the all combination of usage of a `DataTrasfer`, I also
introduce a new enum for redability of data transfer operation, in case
implemented here it is `Ldr`.

Signed-off-by: Federico Guerinoni <guerinoni.federico@gmail.com>
