### PR TITLE
ARM: Implement PC within same bank of 16 register for CPU

### DIFF
--- a/src/condition.rs
+++ b/src/condition.rs
@@ -1,4 +1,5 @@
 /// Arm opcode condition.
+#[derive(Debug, Eq, PartialEq)]
 pub enum Condition {
     EQ = 0x0,
     NE = 0x1,


### PR DESCRIPTION
Before of this PC was a separated variable, in original design PC is only
R15 of array of registers.

Right now in `check_mov_rx_immediate` we verify immediate value from 0 to 15, is this a realistic situation?
Another question, we are advancing PC after `execution`, does this make sense?

We can also skip those question right now, just some thoughts for future work :)
