### PR TITLE
Implement first simple version of memory

### DIFF
--- a/src/arm7tdmi.rs
+++ b/src/arm7tdmi.rs
@@ -3,6 +3,8 @@ use std::convert::TryInto;
 use crate::alu_instruction::ArmModeAluInstruction;
 use crate::bitwise::Bits;
 use crate::instruction::ArmModeInstruction;
+use crate::internal_memory::InternalMemory;
+use crate::io_device::IoDevice;
 use crate::{condition::Condition, cpsr::Cpsr, cpu::Cpu};
 
 /// Contains the 16 registers for the CPU, latest (R15) is special because
@@ -39,6 +41,8 @@ pub struct Arm7tdmi {
 
     registers: Registers,
     cpsr: Cpsr,
+
+    memory: InternalMemory,
 }
 
 const OPCODE_ARM_SIZE: usize = 4;
@@ -113,6 +117,7 @@ impl Arm7tdmi {
             rom,
             registers: Registers::default(),
             cpsr: Cpsr::default(),
+            memory: InternalMemory::new(),
         }
     }
 
@@ -225,15 +230,20 @@ impl Arm7tdmi {
         let load_store: SingleDataTransfer =
             opcode.try_into().expect("convert to Single Data Transfer");
 
+        let value: u32 = self
+            .memory
+            .read_at(if up_down {
+                address.wrapping_sub(offset)
+            } else {
+                address.wrapping_add(offset)
+            })
+            .try_into()
+            .unwrap(); // FIXME: is this right? Or we should read a WORD (u32)
+
         match load_store {
-            SingleDataTransfer::Ldr => self.registers.set_register_at(
-                rd.try_into().unwrap(),
-                if up_down {
-                    address.wrapping_sub(offset)
-                } else {
-                    address.wrapping_add(offset)
-                },
-            ),
+            SingleDataTransfer::Ldr => self
+                .registers
+                .set_register_at(rd.try_into().unwrap(), value),
             _ => todo!(),
         }
     }
@@ -434,8 +444,11 @@ mod tests {
         // then will be 92 + 8 (.wrapping_sub(offset))
         cpu.registers.set_program_counter(92);
 
+        // simulate mem already contains something.
+        cpu.memory.write_at(76, 99);
+
         cpu.execute(op_code, instruction);
-        assert_eq!(cpu.registers.register_at(13), 76);
+        assert_eq!(cpu.registers.register_at(13), 99);
         assert_eq!(cpu.registers.program_counter(), 96);
     }
 }

--- a/src/internal_memory.rs
+++ b/src/internal_memory.rs
@@ -6,7 +6,7 @@ pub struct InternalMemory {
 }
 
 impl InternalMemory {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             internal_work_ram: [0; 0x7FFF],
         }

--- a/src/internal_memory.rs
+++ b/src/internal_memory.rs
@@ -1,0 +1,29 @@
+use crate::io_device::IoDevice;
+
+pub struct InternalMemory {
+    /// From 0x03000000 to 0x03007FFF (32kb).
+    internal_work_ram: [u8; 0x7FFF],
+}
+
+impl InternalMemory {
+    pub fn new() -> Self {
+        Self {
+            internal_work_ram: [0; 0x7FFF],
+        }
+    }
+}
+
+impl IoDevice for InternalMemory {
+    type Address = u32;
+    type Value = u8;
+
+    fn read_at(&self, address: Self::Address) -> Self::Value {
+        let a: usize = address.try_into().unwrap();
+        self.internal_work_ram[a]
+    }
+
+    fn write_at(&mut self, address: Self::Address, value: Self::Value) {
+        let a: usize = address.try_into().unwrap();
+        self.internal_work_ram[a] = value;
+    }
+}

--- a/src/io_device.rs
+++ b/src/io_device.rs
@@ -1,0 +1,7 @@
+pub trait IoDevice {
+    type Address;
+    type Value;
+
+    fn read_at(&self, address: Self::Address) -> Self::Value;
+    fn write_at(&mut self, address: Self::Address, value: Self::Value);
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,8 @@ mod cpsr;
 mod cpu;
 mod egui_app;
 mod instruction;
+mod internal_memory;
+mod io_device;
 mod ppu;
 
 fn main() {


### PR DESCRIPTION
- Memory: Add trait for generic read/write operation
  - Now it is enough simple, without returning result or no byte/word distinction.
    Probably in future we need more specific function but let's start simple.

- Memory: Add `Internal Memory` struct
  - Here I just preparad interal "ram" but we can change the struct name in future based on how we want the granularity of our struct.

- ARM: Add memory field into arm implementation of CPU
  - This allows to fix `SingleDataTransfer::Ldr` istruction.