### PR TITLE
BITS: Added `are_bits_on` function and implemented in ARM.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ target/
 
 # Test roms
 *.gba
+
+# Ignore Visual Studio 
+.vs/

--- a/src/arm7tdmi.rs
+++ b/src/arm7tdmi.rs
@@ -313,13 +313,7 @@ enum SingleDataTransfer {
 
 impl From<u32> for SingleDataTransfer {
     fn from(op_code: u32) -> Self {
-        // TODO: possible improvements
-        // - op_code.are_bits_on(31..28)
-        // - op_code.is_on(31).and(30).and(29)...
-        let must_for_pld = op_code.is_bit_on(31)
-            && op_code.is_bit_on(30)
-            && op_code.is_bit_on(29)
-            && op_code.is_bit_on(28);
+        let must_for_pld = op_code.are_bits_on(28..=31);
         if op_code.get_bit(20) {
             if must_for_pld {
                 Self::Pld

--- a/src/bitwise.rs
+++ b/src/bitwise.rs
@@ -11,6 +11,7 @@ pub trait Bits {
     fn set_bit(&mut self, bit_idx: u8, value: bool);
     fn get_bit(self, bit_idx: u8) -> bool;
     fn get_bits(self, bits_range: RangeInclusive<u8>) -> u32;
+    fn are_bits_on(self, bits_range: RangeInclusive<u8>) -> bool;
 }
 
 impl Bits for u32 {
@@ -68,6 +69,18 @@ impl Bits for u32 {
             bits |= bit_value << shift_value;
         }
         bits
+    }
+
+    ///   Check if the bits in a certein range are all set.
+    ///   Return false when there is at least 1 bit which is 0, true otherwise.
+    ///   When all bits are setted to 1, the check in the inner loop fails and true is returned.
+    fn are_bits_on(self, bits_range: RangeInclusive<u8>) -> bool {
+        for (_, bit_index) in bits_range.enumerate() {
+            if self.is_bit_off(bit_index) {
+                return false;
+            }
+        }
+        true
     }
 }
 
@@ -165,5 +178,12 @@ mod tests {
         assert_eq!(b.get_bits(0..=9), 0b10_1100_1110);
         assert_eq!(b.get_bits(0..=31), 0b10_1100_1110);
         assert_eq!(b.get_bits(28..=31), 0b0);
+    }
+
+    #[test]
+    fn are_bits_on() {
+        let b = 0b1011001110_u32;
+        assert!(!b.are_bits_on(0..=3));
+        assert!(b.are_bits_on(1..=3));
     }
 }


### PR DESCRIPTION
As a form of improvement of the existing functionalities I have implemented the `are_bits_on` function in order to simply check if a certein sub-sequence of bit is all set to 1.
I've made all the necessary tests and the function seems to work just fine so i decided to use it instead of the verbose code in `SingleDataTransfer`.
The code has also been refactored to satisfy project requirements.