### PR TITLE
Add `Opcode` struct

### DIFF
--- a/src/arm7tdmi.rs
+++ b/src/arm7tdmi.rs
@@ -80,7 +80,7 @@ impl Cpu for Arm7tdmi {
             DataProcessing1 | DataProcessing2 | DataProcessing3 => {
                 self.data_processing(op_code);
             }
-            DataTransfer => {
+            TransImm9 => {
                 self.single_data_transfer(op_code);
             }
         }
@@ -110,10 +110,8 @@ impl Arm7tdmi {
 
     fn branch(&mut self, op_code: ArmModeOpcode) {
         let offset = op_code.get_bits(0..=23);
-        println!("offset: {:?}", offset);
 
         self.registers.advance_program_counter(8 + offset * 4);
-        println!("PC: {:?}", self.registers.program_counter());
     }
 
     fn branch_link(&mut self, op_code: ArmModeOpcode) {
@@ -123,7 +121,6 @@ impl Arm7tdmi {
         let offset = op_code.get_bits(0..=23);
 
         self.registers.advance_program_counter(8 + offset * 4);
-        println!("PC: {:?}", self.registers.program_counter());
     }
 
     fn data_processing(&mut self, opcode: ArmModeOpcode) {
@@ -415,7 +412,7 @@ mod tests {
         let mut cpu = Arm7tdmi::new(vec![]);
 
         let op_code_type = cpu.decode(op_code);
-        assert_eq!(op_code_type.instruction, ArmModeInstruction::DataTransfer);
+        assert_eq!(op_code_type.instruction, ArmModeInstruction::TransImm9);
 
         let rd: u8 = ((op_code & 0b0000_0000_0000_0000_1111_0000_0000_0000) >> 12)
             .try_into()

--- a/src/arm7tdmi.rs
+++ b/src/arm7tdmi.rs
@@ -98,7 +98,7 @@ impl Cpu for Arm7tdmi {
         let op_code = self.fetch();
 
         let op_code = self.decode(op_code);
-        if self.cpsr.can_execute(&op_code.condition) {
+        if self.cpsr.can_execute(op_code.condition) {
             self.execute(op_code)
         }
     }

--- a/src/condition.rs
+++ b/src/condition.rs
@@ -1,5 +1,5 @@
 /// Arm opcode condition.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub enum Condition {
     EQ = 0x0,
     NE = 0x1,

--- a/src/cpsr.rs
+++ b/src/cpsr.rs
@@ -7,7 +7,7 @@ use crate::{bitwise::Bits, condition::Condition};
 pub struct Cpsr(u32);
 
 impl Cpsr {
-    pub(crate) fn can_execute(&self, cond: &Condition) -> bool {
+    pub(crate) fn can_execute(&self, cond: Condition) -> bool {
         use Condition::*;
         match cond {
             EQ => self.zero_flag(),                         // Equal (Z=1)

--- a/src/cpsr.rs
+++ b/src/cpsr.rs
@@ -7,7 +7,7 @@ use crate::{bitwise::Bits, condition::Condition};
 pub struct Cpsr(u32);
 
 impl Cpsr {
-    pub(crate) fn can_execute(&self, cond: Condition) -> bool {
+    pub(crate) fn can_execute(&self, cond: &Condition) -> bool {
         use Condition::*;
         match cond {
             EQ => self.zero_flag(),                         // Equal (Z=1)

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1,19 +1,16 @@
-use crate::condition::Condition;
-
 pub trait Cpu {
     /// Size of Opcode: it can be changed
     type OpCodeType;
-    type InstructionType;
 
     /// It generally takes the next instruction from PC
-    fn fetch(&self) -> Self::OpCodeType;
+    fn fetch(&self) -> u32;
 
     /// It decodes the instruction to understand the
     /// OpCode and the variables
-    fn decode(&self, op_code: Self::OpCodeType) -> (Condition, Self::InstructionType);
+    fn decode(&self, op_code: u32) -> Self::OpCodeType;
 
     /// It executes the opcode and updates registers and memory
-    fn execute(&mut self, op_code: u32, instruction_type: Self::InstructionType);
+    fn execute(&mut self, op_code: Self::OpCodeType);
 
     /// Abstraction of what happens for every instruction in the cpu
     fn step(&mut self);

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -8,28 +8,27 @@ pub enum ArmModeInstruction {
     Branch = 0b0000_1010_0000_0000_0000_0000_0000_0000,
     BranchLink = 0b0000_1011_0000_0000_0000_0000_0000_0000,
     TransImm9 = 0b0000_0100_0000_0000_0000_0000_0000_0000,
+    Unknown,
 }
 
-impl TryFrom<u32> for ArmModeInstruction {
-    type Error = String;
-
-    fn try_from(op_code: u32) -> Result<Self, Self::Error> {
+impl From<u32> for ArmModeInstruction {
+    fn from(op_code: u32) -> Self {
         use ArmModeInstruction::*;
 
         if Self::check(DataProcessing1, op_code) {
-            Ok(DataProcessing1)
+            DataProcessing1
         } else if Self::check(DataProcessing2, op_code) {
-            Ok(DataProcessing2)
+            DataProcessing2
         } else if Self::check(DataProcessing3, op_code) {
-            Ok(DataProcessing3)
+            DataProcessing3
         } else if Self::check(Branch, op_code) {
-            Ok(Branch)
+            Branch
         } else if Self::check(BranchLink, op_code) {
-            Ok(BranchLink)
+            BranchLink
         } else if Self::check(TransImm9, op_code) {
-            Ok(TransImm9)
+            TransImm9
         } else {
-            Err("instruction not implemented :(.".to_owned())
+            Unknown
         }
     }
 }
@@ -47,6 +46,7 @@ impl ArmModeInstruction {
             DataProcessing1 | DataProcessing2 => 0b0000_1110_0000_0000_0000_0000_0001_0000,
             DataProcessing3 => 0b0000_1110_0000_0000_0000_0000_0000_0000,
             TransImm9 => 0b0000_1110_0000_0000_0000_0000_0000_0000,
+            Unknown => 0b1111_1111_1111_1111_1111_1111_1111_1111,
         }
     }
 }

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -7,7 +7,7 @@ pub enum ArmModeInstruction {
     DataProcessing3 = 0b0000_0010_0000_0000_0000_0000_0000_0000,
     Branch = 0b0000_1010_0000_0000_0000_0000_0000_0000,
     BranchLink = 0b0000_1011_0000_0000_0000_0000_0000_0000,
-    DataTransfer = 0b0000_0100_0000_0000_0000_0000_0000_0000,
+    TransImm9 = 0b0000_0100_0000_0000_0000_0000_0000_0000,
 }
 
 impl TryFrom<u32> for ArmModeInstruction {
@@ -26,8 +26,8 @@ impl TryFrom<u32> for ArmModeInstruction {
             Ok(Branch)
         } else if Self::check(BranchLink, op_code) {
             Ok(BranchLink)
-        } else if Self::check(DataTransfer, op_code) {
-            Ok(DataTransfer)
+        } else if Self::check(TransImm9, op_code) {
+            Ok(TransImm9)
         } else {
             Err("instruction not implemented :(.".to_owned())
         }
@@ -46,7 +46,7 @@ impl ArmModeInstruction {
             Branch | BranchLink => 0b0000_1111_0000_0000_0000_0000_0000_0000,
             DataProcessing1 | DataProcessing2 => 0b0000_1110_0000_0000_0000_0000_0001_0000,
             DataProcessing3 => 0b0000_1110_0000_0000_0000_0000_0000_0000,
-            DataTransfer => 0b0000_1100_0000_0000_0000_0000_0000_0000,
+            TransImm9 => 0b0000_1110_0000_0000_0000_0000_0000_0000,
         }
     }
 }
@@ -59,7 +59,7 @@ impl Display for ArmModeInstruction {
             Self::DataProcessing3 => "DataProcessing3",
             Self::Branch => "Branch",
             Self::BranchLink => "BranchLink",
-            Self::DataTransfer => "DataTransfer",
+            Self::TransImm9 => "TransImm9",
         };
 
         write!(f, "{}", instruction_str)

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -53,15 +53,6 @@ impl ArmModeInstruction {
 
 impl Display for ArmModeInstruction {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let instruction_str = match self {
-            Self::DataProcessing1 => "DataProcessing1",
-            Self::DataProcessing2 => "DataProcessing2",
-            Self::DataProcessing3 => "DataProcessing3",
-            Self::Branch => "Branch",
-            Self::BranchLink => "BranchLink",
-            Self::TransImm9 => "TransImm9",
-        };
-
-        write!(f, "{}", instruction_str)
+        write!(f, "{:?}", self)
     }
 }

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -1,3 +1,5 @@
+use std::fmt::{Display, Formatter};
+
 #[derive(Debug, PartialEq, Eq)]
 pub enum ArmModeInstruction {
     DataProcessing1 = 0b0000_0000_0000_0000_0000_0000_0000_0000,
@@ -46,5 +48,20 @@ impl ArmModeInstruction {
             DataProcessing3 => 0b0000_1110_0000_0000_0000_0000_0000_0000,
             DataTransfer => 0b0000_1100_0000_0000_0000_0000_0000_0000,
         }
+    }
+}
+
+impl Display for ArmModeInstruction {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let instruction_str = match self {
+            Self::DataProcessing1 => "DataProcessing1",
+            Self::DataProcessing2 => "DataProcessing2",
+            Self::DataProcessing3 => "DataProcessing3",
+            Self::Branch => "Branch",
+            Self::BranchLink => "BranchLink",
+            Self::DataTransfer => "DataTransfer",
+        };
+
+        write!(f, "{}", instruction_str)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ mod egui_app;
 mod instruction;
 mod internal_memory;
 mod io_device;
+mod opcode;
 mod ppu;
 
 fn main() {

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -15,7 +15,7 @@ impl TryFrom<u32> for ArmModeOpcode {
 
     fn try_from(opcode: u32) -> Result<Self, Self::Error> {
         Ok(Self {
-            instruction: ArmModeInstruction::try_from(opcode)?,
+            instruction: ArmModeInstruction::from(opcode),
             condition: Condition::from(opcode.get_bits(28..=31) as u8),
             raw: opcode,
         })
@@ -54,6 +54,7 @@ impl Display for ArmModeOpcode {
             ArmModeInstruction::Branch | ArmModeInstruction::BranchLink => {
                 "FMT: |_Cond__|1_0_1|L|___________________Offset______________________|\n"
             }
+            ArmModeInstruction::Unknown => "",
         };
 
         let cond = self.get_bits(28..=31);
@@ -119,6 +120,7 @@ impl Display for ArmModeOpcode {
                      BIN: |{cond:07b}|1_0_1|{l:01b}|{offset:047b}|\n"
                 )
             }
+            ArmModeInstruction::Unknown => String::new(),
         };
 
         let mut raw_bits = String::new();

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1,5 +1,7 @@
-use std::ops::Deref;
+use crate::bitwise::Bits;
 use crate::instruction::ArmModeInstruction;
+use std::fmt::{Display, Formatter};
+use std::ops::Deref;
 
 pub struct Opcode {
     pub instruction: ArmModeInstruction,
@@ -22,5 +24,66 @@ impl Deref for Opcode {
 
     fn deref(&self) -> &Self::Target {
         &self.raw
+    }
+}
+
+impl Display for Opcode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let instruction = self.instruction.to_string();
+        let instruction = format!("INS: {}\n", instruction);
+
+        let bytes_pos1 = "POS: |..3 ..................2 ..................1 ..................0|\n";
+        let bytes_pos2 = "     |1_0_9_8_7_6_5_4_3_2_1_0_9_8_7_6_5_4_3_2_1_0_9_8_7_6_5_4_3_2_1_0|\n";
+
+        let opcode_format: &str = match self.instruction {
+            ArmModeInstruction::DataProcessing1 => {
+                "FMT: |_Cond__|0_0_0|___Op__|S|__Rn___|__Rd___|__Shift__|Typ|0|__Rm___|\n"
+            }
+            ArmModeInstruction::Branch => {
+                "FMT: |_Cond__|1_0_1|L|___________________Offset______________________|\n"
+            }
+            _ => todo!(),
+        };
+
+        let cond = self.get_bits(28..=31);
+        let opcode_value: String = match self.instruction {
+            ArmModeInstruction::DataProcessing1 => {
+                let op = self.get_bits(21..=24);
+                let s = self.get_bit(20) as u8;
+                let rn = self.get_bits(16..=19);
+                let rd = self.get_bits(12..=15);
+                let shift_amount = self.get_bits(7..=11);
+                let shift_type = self.get_bits(5..=6);
+                let rm = self.get_bits(0..=3);
+
+                format!("HEX: |{cond:07X}|0_0_0|{op:07X}|{s:01X}|{rn:07X}|{rd:07X}|{shift_amount:09X}|{shift_type:03X}|0|{rm:07X}|\n\
+                         DEC: |{cond:07}|0_0_0|{op:07}|{s:01}|{rn:07}|{rd:07}|{shift_amount:09}|{shift_type:03}|0|{rm:07}|\n\
+                         BIN: |{cond:07b}|0_0_0|{op:07b}|{s:01b}|{rn:07b}|{rd:07b}|{shift_amount:09b}|{shift_type:03b}|0|{rm:07b}|\n")
+            }
+
+            ArmModeInstruction::Branch => {
+                let l = self.get_bit(24) as u8;
+                let offset = self.get_bits(0..=23);
+                format!(
+                    "HEX: |{cond:07X}|1_0_1|{l:01X}|{offset:047X}|\n\
+                         DEC: |{cond:07}|1_0_1|{l:01}|{offset:047}|\n\
+                         BIN: |{cond:07b}|1_0_1|{l:01b}|{offset:047b}|\n"
+                )
+            }
+            _ => todo!(),
+        };
+
+        let mut raw_bits = String::new();
+        for i in format!("{:b}", self.raw).chars() {
+            raw_bits.push(i);
+            raw_bits.push('_');
+        }
+        raw_bits.pop();
+        let raw_bits = format!("RAW: |{}|\n", raw_bits);
+
+        write!(
+            f,
+            "{instruction}{bytes_pos1}{bytes_pos2}{raw_bits}{opcode_format}{opcode_value}"
+        )
     }
 }

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -48,10 +48,12 @@ impl Display for ArmModeOpcode {
             ArmModeInstruction::DataProcessing3 => {
                 "FMT: |_Cond__|0_0_1|___Op__|S|__Rn___|__Rd___|_Shift_|___Immediate___|\n"
             }
+            ArmModeInstruction::TransImm9 => {
+                "FMT: |_Cond__|0_1_0|P|U|B|W|L|__Rn___|__Rd___|_________Offset________|\n"
+            }
             ArmModeInstruction::Branch | ArmModeInstruction::BranchLink => {
                 "FMT: |_Cond__|1_0_1|L|___________________Offset______________________|\n"
             }
-            _ => todo!(),
         };
 
         let cond = self.get_bits(28..=31);
@@ -94,6 +96,20 @@ impl Display for ArmModeOpcode {
                          DEC: |{cond:07}|0_0_1|{op:07}|{s:01}|{rn:07}|{rd:07}|{shift_amount:07}|{immediate:015}|\n\
                          BIN: |{cond:07b}|0_0_1|{op:07b}|{s:01b}|{rn:07b}|{rd:07b}|{shift_amount:07b}|{immediate:015b}|\n")
             }
+            ArmModeInstruction::TransImm9 => {
+                let p = self.get_bit(24) as u8;
+                let u = self.get_bit(23) as u8;
+                let b = self.get_bit(22) as u8;
+                let w = self.get_bit(21) as u8;
+                let l = self.get_bit(20) as u8;
+                let rn = self.get_bits(16..=19);
+                let rd = self.get_bits(12..=15);
+                let offset = self.get_bits(0..=11);
+
+                format!("HEX: |{cond:07X}|0_1_0|{p:01X}|{u:01X}|{b:01X}|{w:01X}|{l:01X}|{rn:07X}|{rd:07X}|{offset:023X}|\n\
+                         DEC: |{cond:07}|0_1_0|{p:01}|{u:01}|{b:01}|{w:01}|{l:01}|{rn:07}|{rd:07}|{offset:023}|\n\
+                         BIN: |{cond:07b}|0_1_0|{p:01b}|{u:01b}|{b:01b}|{w:01b}|{l:01b}|{rn:07b}|{rd:07b}|{offset:023b}|\n")
+            }
             ArmModeInstruction::Branch | ArmModeInstruction::BranchLink => {
                 let l = self.get_bit(24) as u8;
                 let offset = self.get_bits(0..=23);
@@ -103,7 +119,6 @@ impl Display for ArmModeOpcode {
                      BIN: |{cond:07b}|1_0_1|{l:01b}|{offset:047b}|\n"
                 )
             }
-            _ => todo!(),
         };
 
         let mut raw_bits = String::new();

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -42,7 +42,13 @@ impl Display for ArmModeOpcode {
             ArmModeInstruction::DataProcessing1 => {
                 "FMT: |_Cond__|0_0_0|___Op__|S|__Rn___|__Rd___|__Shift__|Typ|0|__Rm___|\n"
             }
-            ArmModeInstruction::Branch => {
+            ArmModeInstruction::DataProcessing2 => {
+                "FMT: |_Cond__|0_0_0|___Op__|S|__Rn___|__Rd___|__Rs___|0|Typ|1|__Rm___|\n"
+            }
+            ArmModeInstruction::DataProcessing3 => {
+                "FMT: |_Cond__|0_0_1|___Op__|S|__Rn___|__Rd___|_Shift_|___Immediate___|\n"
+            }
+            ArmModeInstruction::Branch | ArmModeInstruction::BranchLink => {
                 "FMT: |_Cond__|1_0_1|L|___________________Offset______________________|\n"
             }
             _ => todo!(),
@@ -63,8 +69,32 @@ impl Display for ArmModeOpcode {
                          DEC: |{cond:07}|0_0_0|{op:07}|{s:01}|{rn:07}|{rd:07}|{shift_amount:09}|{shift_type:03}|0|{rm:07}|\n\
                          BIN: |{cond:07b}|0_0_0|{op:07b}|{s:01b}|{rn:07b}|{rd:07b}|{shift_amount:09b}|{shift_type:03b}|0|{rm:07b}|\n")
             }
+            ArmModeInstruction::DataProcessing2 => {
+                let op = self.get_bits(21..=24);
+                let s = self.get_bit(20) as u8;
+                let rn = self.get_bits(16..=19);
+                let rd = self.get_bits(12..=15);
+                let rs = self.get_bits(8..=11);
+                let shift_type = self.get_bits(5..=6);
+                let rm = self.get_bits(0..=3);
 
-            ArmModeInstruction::Branch => {
+                format!("HEX: |{cond:07X}|0_0_0|{op:07X}|{s:01X}|{rn:07X}|{rd:07X}|{rs:07X}|0|{shift_type:03X}|1|{rm:07X}|\n\
+                         DEC: |{cond:07}|0_0_0|{op:07}|{s:01}|{rn:07}|{rd:07}|{rs:07}|0|{shift_type:03}|1|{rm:07}|\n\
+                         BIN: |{cond:07b}|0_0_0|{op:07b}|{s:01b}|{rn:07b}|{rd:07b}|{rs:07b}|0|{shift_type:03b}|1|{rm:07b}|\n")
+            }
+            ArmModeInstruction::DataProcessing3 => {
+                let op = self.get_bits(21..=24);
+                let s = self.get_bit(20) as u8;
+                let rn = self.get_bits(16..=19);
+                let rd = self.get_bits(12..=15);
+                let shift_amount = self.get_bits(8..=11);
+                let immediate = self.get_bits(0..=7);
+
+                format!("HEX: |{cond:07X}|0_0_1|{op:07X}|{s:01X}|{rn:07X}|{rd:07X}|{shift_amount:07X}|{immediate:015X}|\n\
+                         DEC: |{cond:07}|0_0_1|{op:07}|{s:01}|{rn:07}|{rd:07}|{shift_amount:07}|{immediate:015}|\n\
+                         BIN: |{cond:07b}|0_0_1|{op:07b}|{s:01b}|{rn:07b}|{rd:07b}|{shift_amount:07b}|{immediate:015b}|\n")
+            }
+            ArmModeInstruction::Branch | ArmModeInstruction::BranchLink => {
                 let l = self.get_bit(24) as u8;
                 let offset = self.get_bits(0..=23);
                 format!(

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1,25 +1,28 @@
 use crate::bitwise::Bits;
+use crate::condition::Condition;
 use crate::instruction::ArmModeInstruction;
 use std::fmt::{Display, Formatter};
 use std::ops::Deref;
 
-pub struct Opcode {
+pub struct ArmModeOpcode {
     pub instruction: ArmModeInstruction,
+    pub condition: Condition,
     pub raw: u32,
 }
 
-impl TryFrom<u32> for Opcode {
+impl TryFrom<u32> for ArmModeOpcode {
     type Error = String;
 
     fn try_from(opcode: u32) -> Result<Self, Self::Error> {
         Ok(Self {
             instruction: ArmModeInstruction::try_from(opcode)?,
+            condition: Condition::from(opcode.get_bits(28..=31) as u8),
             raw: opcode,
         })
     }
 }
 
-impl Deref for Opcode {
+impl Deref for ArmModeOpcode {
     type Target = u32;
 
     fn deref(&self) -> &Self::Target {
@@ -27,7 +30,7 @@ impl Deref for Opcode {
     }
 }
 
-impl Display for Opcode {
+impl Display for ArmModeOpcode {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let instruction = self.instruction.to_string();
         let instruction = format!("INS: {}\n", instruction);
@@ -66,8 +69,8 @@ impl Display for Opcode {
                 let offset = self.get_bits(0..=23);
                 format!(
                     "HEX: |{cond:07X}|1_0_1|{l:01X}|{offset:047X}|\n\
-                         DEC: |{cond:07}|1_0_1|{l:01}|{offset:047}|\n\
-                         BIN: |{cond:07b}|1_0_1|{l:01b}|{offset:047b}|\n"
+                     DEC: |{cond:07}|1_0_1|{l:01}|{offset:047}|\n\
+                     BIN: |{cond:07b}|1_0_1|{l:01b}|{offset:047b}|\n"
                 )
             }
             _ => todo!(),

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1,0 +1,17 @@
+use crate::instruction::ArmModeInstruction;
+
+pub struct Opcode {
+    pub instruction: ArmModeInstruction,
+    pub raw_value: u32,
+}
+
+impl TryFrom<u32> for Opcode {
+    type Error = String;
+
+    fn try_from(opcode: u32) -> Result<Self, Self::Error> {
+        Ok(Self {
+            instruction: ArmModeInstruction::try_from(opcode)?,
+            raw_value: opcode,
+        })
+    }
+}

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1,8 +1,9 @@
+use std::ops::Deref;
 use crate::instruction::ArmModeInstruction;
 
 pub struct Opcode {
     pub instruction: ArmModeInstruction,
-    pub raw_value: u32,
+    pub raw: u32,
 }
 
 impl TryFrom<u32> for Opcode {
@@ -11,7 +12,15 @@ impl TryFrom<u32> for Opcode {
     fn try_from(opcode: u32) -> Result<Self, Self::Error> {
         Ok(Self {
             instruction: ArmModeInstruction::try_from(opcode)?,
-            raw_value: opcode,
+            raw: opcode,
         })
+    }
+}
+
+impl Deref for Opcode {
+    type Target = u32;
+
+    fn deref(&self) -> &Self::Target {
+        &self.raw
     }
 }


### PR DESCRIPTION
I think using `u32` to handle opcodes has become frustrating and confusing. Therefore, I created a structure that can handle the main functions of the opcode: 
- Condition
- Instruction
- Bits Manipulation
- Debug/Display

Unfortunately, the `Display` support for `Single Data Transfer` is missing since currently `ArmModeInstruction::DataTransfer` is used to represent multiple instructions at once. Therefore, it is necessary to divide `DataTransfer` in a manner similar 
to `DataProcessing` (1, 2, and 3). BTW, If you do not use the `Display` trait of `Opcode` in `Arm7tdmi::decode()` everything works as before.
