### PR TITLE
`ORR` and some `ADD` fixes

### DIFF
--- a/emu/src/arm7tdmi.rs
+++ b/emu/src/arm7tdmi.rs
@@ -207,7 +207,7 @@ impl Arm7tdmi {
             }
             ArmModeAluInstruction::Add => self.add(
                 rd.try_into().unwrap(),
-                rn,
+                self.registers.register_at(rn.try_into().unwrap()),
                 op2,
                 s,
             ),
@@ -513,14 +513,13 @@ mod tests {
 
     #[test]
     fn check_add() {
-        {
-            let op_code = 0b1110_0010_1000_1111_0000_0000_0010_0000;
-            let mut cpu = Arm7tdmi::new(vec![]);
-            let op_code = cpu.decode(op_code);
-            assert_eq!(op_code.instruction, ArmModeInstruction::DataProcessing3);
-            cpu.execute(op_code);
-            assert_eq!(cpu.registers.register_at(0), 15 + 32);
-        }
+        let op_code = 0b1110_0010_1000_1111_0000_0000_0010_0000;
+        let mut cpu = Arm7tdmi::new(vec![]);
+        let op_code = cpu.decode(op_code);
+        assert_eq!(op_code.instruction, ArmModeInstruction::DataProcessing3);
+        cpu.registers.set_register_at(15, 15);
+        cpu.execute(op_code);
+        assert_eq!(cpu.registers.register_at(0), 15 + 32);
     }
 
     #[test]

--- a/emu/src/arm7tdmi.rs
+++ b/emu/src/arm7tdmi.rs
@@ -157,7 +157,9 @@ impl Arm7tdmi {
                 // bit [4] - is Shift by Register Flag (0=Immediate, 1=Register)
                 let r = op_code.get_bit(4);
                 // bits [0-3] 2nd Operand Register (R0..R15) (including PC=R15)
-                let mut op2 = op_code.get_bits(0..=3);
+                let mut op2 = self
+                    .registers
+                    .register_at(op_code.get_bits(0..=3).try_into().unwrap());
 
                 match r {
                     // 0=Immediate, 1=Register

--- a/emu/src/arm7tdmi.rs
+++ b/emu/src/arm7tdmi.rs
@@ -206,7 +206,13 @@ impl Arm7tdmi {
                 }
             }
             ArmModeAluInstruction::Add => self.add(rd.try_into().unwrap(), rn, op2),
-            _ => todo!("implement alu operation"),
+            ArmModeAluInstruction::Orr => self.orr(
+                rd.try_into().unwrap(),
+                self.registers.register_at(rn.try_into().unwrap()),
+                op2,
+                s,
+            ),
+            _ => todo!("implement alu operation: {}", alu_op_code),
         }
     }
 
@@ -259,6 +265,17 @@ impl Arm7tdmi {
 
     fn add(&mut self, rd: usize, rn: u32, op2: u32) {
         self.registers.set_register_at(rd, rn.wrapping_add(op2));
+    }
+
+    fn orr(&mut self, rd: usize, rn: u32, op2: u32, s: bool) {
+        let result: u32 = rn | op2;
+
+        self.registers.set_register_at(rd, result);
+
+        if s {
+            self.cpsr.set_zero_flag(result == 0);
+            self.cpsr.set_sign_flag(result.is_bit_on(31));
+        }
     }
 
     fn mov(&mut self, rd: usize, op2: u32) {

--- a/emu/src/cpsr.rs
+++ b/emu/src/cpsr.rs
@@ -106,7 +106,6 @@ impl Cpsr {
         self.0.set_bit(30, value);
     }
 
-    #[cfg(test)] // TODO: remove cfg when this API will be used at least one in prod code.
     pub fn set_carry_flag(&mut self, value: bool) {
         self.0.set_bit(29, value);
     }


### PR DESCRIPTION
This PR adds support for `ORR` instruction and changes `ADD` behavior in some cases.

In the `data_processing` function, when the immediate bit was 0, `op2` was being set to the `[3:0]` value, instead of reading the value from the register. I think this was because the `shift` function was intended to read this value from the register, but right now it's not happening in every case (only when `shift_amount == 0` and `shift_type == 1 or 2`). And to me, the `shift` function should not have the responsibility to read from the register, in any case.

The same thing was happening in the `ADD`: the `Rn` operand was being directly used as value in the operation, instead of reading it from the register. I've also added `CPSR` bits output to the `ADD` instruction.

This PR probably breaks the `shift` function in the cases where it reads the value from the register, tell me if we should "refactor" it in this PR.