### PR TITLE
Refactor shift operand

### DIFF
--- a/emu/src/alu_instruction.rs
+++ b/emu/src/alu_instruction.rs
@@ -17,6 +17,26 @@ pub enum ArmModeAluInstruction {
     Mvn = 0xF,
 }
 
+#[derive(Eq, PartialEq, Debug)]
+pub enum AluInstructionKind {
+    Logical,
+    Arithmetic,
+}
+
+pub trait Kind {
+    fn kind(&self) -> AluInstructionKind;
+}
+
+impl Kind for ArmModeAluInstruction {
+    fn kind(&self) -> AluInstructionKind {
+        use ArmModeAluInstruction::*;
+        match &self {
+            And | Eor | Tst | Teq | Orr | Mov | Bic | Mvn => AluInstructionKind::Logical,
+            Sub | Rsb | Add | Adc | Sbc | Rsc | Cmp | Cmn => AluInstructionKind::Arithmetic,
+        }
+    }
+}
+
 impl From<u32> for ArmModeAluInstruction {
     fn from(alu_op_code: u32) -> Self {
         use ArmModeAluInstruction::*;
@@ -39,5 +59,26 @@ impl From<u32> for ArmModeAluInstruction {
             0xF => Mvn,
             _ => unreachable!(),
         }
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_logical_instruction() {
+        let alu_op_code = 9;
+        let instruction_kind = ArmModeAluInstruction::from(alu_op_code).kind();
+
+        assert_eq!(instruction_kind, AluInstructionKind::Logical);
+    }
+
+    #[test]
+    fn test_arithmetic_instruction() {
+        let alu_op_code = 2;
+        let instruction_kind = ArmModeAluInstruction::from(alu_op_code).kind();
+
+        assert_eq!(instruction_kind, AluInstructionKind::Arithmetic);
     }
 }


### PR DESCRIPTION
I've refactored a bit and completed the shift op2 logic.

* Added `Type` trait for ALU instructions to know if it is logical or arithmetical
* I moved the `get_operand` logic to a separate function
* I refactored a bit the `shift` logic: now barrel shifter operations correctly set the carry flag when the instruction is logical and `S` is set

I know that `09a20b5b9f95fbc6f301b13b321c79b194b1f9f7` is big but it doesn't make sense to me to split it, since it's all about the same task, but let me know :)


I think the barrel shifter logic is complex enough to be worth quite some tests. I didn't have time yet to add them but they're for sure needed.