### PR TITLE
Adding `LCDRegisters` mapping to `InternalMemory`

### DIFF
--- a/emu/src/arm7tdmi.rs
+++ b/emu/src/arm7tdmi.rs
@@ -625,15 +625,15 @@ mod tests {
         assert_eq!(rd, 13);
 
         // because in this specific case address will be
-        // then will be 92 + 8 (.wrapping_sub(offset))
-        cpu.registers.set_program_counter(92);
+        // then will be 0x03000050 + 8 (.wrapping_sub(offset))
+        cpu.registers.set_program_counter(0x03000050);
 
         // simulate mem already contains something.
-        cpu.memory.write_at(76, 99);
+        cpu.memory.write_at(0x03000040, 99);
 
         cpu.execute(op_code_type);
         assert_eq!(cpu.registers.register_at(13), 99);
-        assert_eq!(cpu.registers.program_counter(), 96);
+        assert_eq!(cpu.registers.program_counter(), 0x03000054);
     }
 
     #[test]

--- a/emu/src/bitwise.rs
+++ b/emu/src/bitwise.rs
@@ -9,9 +9,9 @@ pub trait Bits {
     fn set_bit_off(&mut self, bit_idx: u8);
     fn toggle_bit(&mut self, bit_idx: u8);
     fn set_bit(&mut self, bit_idx: u8, value: bool);
-    fn get_bit(self, bit_idx: u8) -> bool;
-    fn get_bits(self, bits_range: RangeInclusive<u8>) -> u32;
-    fn are_bits_on(self, bits_range: RangeInclusive<u8>) -> bool;
+    fn get_bit(&self, bit_idx: u8) -> bool;
+    fn get_bits(&self, bits_range: RangeInclusive<u8>) -> u32;
+    fn are_bits_on(&self, bits_range: RangeInclusive<u8>) -> bool;
     fn get_byte(&self, byte_nth: u8) -> u8;
     fn set_byte(&mut self, byte_nth: u8, value: u8);
 }
@@ -60,11 +60,11 @@ impl Bits for u32 {
         }
     }
 
-    fn get_bit(self, bit_idx: u8) -> bool {
+    fn get_bit(&self, bit_idx: u8) -> bool {
         self.is_bit_on(bit_idx)
     }
 
-    fn get_bits(self, bits_range: RangeInclusive<u8>) -> u32 {
+    fn get_bits(&self, bits_range: RangeInclusive<u8>) -> u32 {
         let mut bits = 0b0;
         for (shift_value, bit_index) in bits_range.enumerate() {
             let bit_value: Self = self.get_bit(bit_index).into();
@@ -76,7 +76,7 @@ impl Bits for u32 {
     /// Checks if a certein sequence of bit is set to 1.
     /// Return false whenever there is a least one bit which is set to 0, true otherwise.
     /// When all bits are set to 1, the if statement fails and true is returned.
-    fn are_bits_on(self, bits_range: RangeInclusive<u8>) -> bool {
+    fn are_bits_on(&self, bits_range: RangeInclusive<u8>) -> bool {
         for (_, bit_index) in bits_range.enumerate() {
             if self.is_bit_off(bit_index) {
                 return false;
@@ -88,7 +88,7 @@ impl Bits for u32 {
     fn get_byte(&self, byte_nth: u8) -> u8 {
         if byte_nth > 3 {
             panic!("Byte number must be a value between 0 and 3.");
-}
+        }
 
         // We access the byte_nth octect:
         // from the byte_nth*8 bit to the byte_nth*8+7 bit (inclusive)

--- a/emu/src/internal_memory.rs
+++ b/emu/src/internal_memory.rs
@@ -149,7 +149,7 @@ impl IoDevice for InternalMemory {
 
     fn read_at(&self, address: Self::Address) -> Self::Value {
         match address {
-            0x03000000..=0x03007FFF => self.internal_work_ram[address as usize],
+            0x03000000..=0x03007FFF => self.internal_work_ram[(address - 0x03000000) as usize],
             0x04000000..=0x04000055 => self.read_address_lcd_register(address),
             _ => unimplemented!("Unimplemented memory region."),
         }
@@ -158,7 +158,7 @@ impl IoDevice for InternalMemory {
     fn write_at(&mut self, address: Self::Address, value: Self::Value) {
         match address {
             0x03000000..=0x03007FFF => {
-                self.internal_work_ram[address as usize] = value
+                self.internal_work_ram[(address - 0x03000000) as usize] = value
             }
             0x04000000..=0x04000055 => self.write_address_lcd_register(address, value),
             _ => unimplemented!("Unimplemented memory region."),

--- a/emu/src/internal_memory.rs
+++ b/emu/src/internal_memory.rs
@@ -1,14 +1,144 @@
+use crate::bitwise::Bits;
 use crate::io_device::IoDevice;
+use crate::io_registers::LCDRegisters;
 
 pub struct InternalMemory {
     /// From 0x03000000 to 0x03007FFF (32kb).
     internal_work_ram: [u8; 0x7FFF],
+    /// From 0x04000000 to 0x04000055 (0x56 bytes).
+    lcd_registers: LCDRegisters,
+}
+
+impl Default for InternalMemory {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl InternalMemory {
     pub const fn new() -> Self {
         Self {
             internal_work_ram: [0; 0x7FFF],
+            lcd_registers: LCDRegisters::new(),
+        }
+    }
+
+    fn write_address_lcd_register(&mut self, address: u32, value: u8) {
+        match address {
+            0x04000000 => self.lcd_registers.dispcnt.set_byte(0, value),
+            0x04000001 => self.lcd_registers.dispcnt.set_byte(1, value),
+            0x04000002 => self.lcd_registers.green_swap.set_byte(0, value),
+            0x04000003 => self.lcd_registers.green_swap.set_byte(1, value),
+            0x04000004 => self.lcd_registers.dispstat.set_byte(0, value),
+            0x04000005 => self.lcd_registers.dispstat.set_byte(1, value),
+            0x04000008 => self.lcd_registers.bg0cnt.set_byte(0, value),
+            0x04000009 => self.lcd_registers.bg0cnt.set_byte(1, value),
+            0x0400000A => self.lcd_registers.bg1cnt.set_byte(0, value),
+            0x0400000B => self.lcd_registers.bg1cnt.set_byte(1, value),
+            0x0400000C => self.lcd_registers.bg2cnt.set_byte(0, value),
+            0x0400000D => self.lcd_registers.bg2cnt.set_byte(1, value),
+            0x0400000E => self.lcd_registers.bg3cnt.set_byte(0, value),
+            0x0400000F => self.lcd_registers.bg3cnt.set_byte(1, value),
+            0x04000010 => self.lcd_registers.bg0hofs.set_byte(0, value),
+            0x04000011 => self.lcd_registers.bg0hofs.set_byte(1, value),
+            0x04000012 => self.lcd_registers.bg0vofs.set_byte(0, value),
+            0x04000013 => self.lcd_registers.bg0vofs.set_byte(1, value),
+            0x04000014 => self.lcd_registers.bg1hofs.set_byte(0, value),
+            0x04000015 => self.lcd_registers.bg1hofs.set_byte(1, value),
+            0x04000016 => self.lcd_registers.bg1vofs.set_byte(0, value),
+            0x04000017 => self.lcd_registers.bg1vofs.set_byte(1, value),
+            0x04000018 => self.lcd_registers.bg2hofs.set_byte(0, value),
+            0x04000019 => self.lcd_registers.bg2hofs.set_byte(1, value),
+            0x0400001A => self.lcd_registers.bg2vofs.set_byte(0, value),
+            0x0400001B => self.lcd_registers.bg2vofs.set_byte(1, value),
+            0x0400001C => self.lcd_registers.bg3hofs.set_byte(0, value),
+            0x0400001D => self.lcd_registers.bg3hofs.set_byte(1, value),
+            0x0400001E => self.lcd_registers.bg3vofs.set_byte(0, value),
+            0x0400001F => self.lcd_registers.bg3vofs.set_byte(1, value),
+            0x04000020 => self.lcd_registers.bg2pa.set_byte(0, value),
+            0x04000021 => self.lcd_registers.bg2pa.set_byte(1, value),
+            0x04000022 => self.lcd_registers.bg2pb.set_byte(0, value),
+            0x04000023 => self.lcd_registers.bg2pb.set_byte(1, value),
+            0x04000024 => self.lcd_registers.bg2pc.set_byte(0, value),
+            0x04000025 => self.lcd_registers.bg2pc.set_byte(1, value),
+            0x04000026 => self.lcd_registers.bg2pd.set_byte(0, value),
+            0x04000027 => self.lcd_registers.bg2pd.set_byte(1, value),
+            0x04000028 => self.lcd_registers.bg2x.set_byte(0, value),
+            0x04000029 => self.lcd_registers.bg2x.set_byte(1, value),
+            0x0400002A => self.lcd_registers.bg2x.set_byte(2, value),
+            0x0400002B => self.lcd_registers.bg2x.set_byte(3, value),
+            0x0400002C => self.lcd_registers.bg2y.set_byte(0, value),
+            0x0400002D => self.lcd_registers.bg2y.set_byte(1, value),
+            0x0400002E => self.lcd_registers.bg2y.set_byte(2, value),
+            0x0400002F => self.lcd_registers.bg2y.set_byte(3, value),
+            0x04000030 => self.lcd_registers.bg3pa.set_byte(0, value),
+            0x04000031 => self.lcd_registers.bg3pa.set_byte(1, value),
+            0x04000032 => self.lcd_registers.bg3pb.set_byte(0, value),
+            0x04000033 => self.lcd_registers.bg3pb.set_byte(1, value),
+            0x04000034 => self.lcd_registers.bg3pc.set_byte(0, value),
+            0x04000035 => self.lcd_registers.bg3pc.set_byte(1, value),
+            0x04000036 => self.lcd_registers.bg3pd.set_byte(0, value),
+            0x04000037 => self.lcd_registers.bg3pd.set_byte(1, value),
+            0x04000038 => self.lcd_registers.bg3x.set_byte(0, value),
+            0x04000039 => self.lcd_registers.bg3x.set_byte(1, value),
+            0x0400003A => self.lcd_registers.bg3x.set_byte(2, value),
+            0x0400003B => self.lcd_registers.bg3x.set_byte(3, value),
+            0x0400003C => self.lcd_registers.bg3y.set_byte(0, value),
+            0x0400003D => self.lcd_registers.bg3y.set_byte(1, value),
+            0x0400003E => self.lcd_registers.bg3y.set_byte(2, value),
+            0x0400003F => self.lcd_registers.bg3y.set_byte(3, value),
+            0x04000040 => self.lcd_registers.win0h.set_byte(0, value),
+            0x04000041 => self.lcd_registers.win0h.set_byte(1, value),
+            0x04000042 => self.lcd_registers.win1h.set_byte(0, value),
+            0x04000043 => self.lcd_registers.win1h.set_byte(1, value),
+            0x04000044 => self.lcd_registers.win0v.set_byte(0, value),
+            0x04000045 => self.lcd_registers.win0v.set_byte(1, value),
+            0x04000046 => self.lcd_registers.win1v.set_byte(0, value),
+            0x04000047 => self.lcd_registers.win1v.set_byte(1, value),
+            0x04000048 => self.lcd_registers.winin.set_byte(0, value),
+            0x04000049 => self.lcd_registers.winin.set_byte(1, value),
+            0x0400004A => self.lcd_registers.winout.set_byte(0, value),
+            0x0400004B => self.lcd_registers.winout.set_byte(1, value),
+            0x0400004C => self.lcd_registers.mosaic.set_byte(0, value),
+            0x0400004D => self.lcd_registers.mosaic.set_byte(1, value),
+            // 0x0400004E, 0x0400004F are not used
+            0x04000050 => self.lcd_registers.bldcnt.set_byte(0, value),
+            0x04000051 => self.lcd_registers.bldcnt.set_byte(1, value),
+            0x04000052 => self.lcd_registers.bldalpha.set_byte(0, value),
+            0x04000053 => self.lcd_registers.bldalpha.set_byte(1, value),
+            0x04000054 => self.lcd_registers.bldy.set_byte(0, value),
+            0x04000055 => self.lcd_registers.bldy.set_byte(1, value),
+            _ => panic!("Writing an read-only memory address: {address:b}"),
+        }
+    }
+
+    fn read_address_lcd_register(&self, address: u32) -> u8 {
+        match address {
+            0x04000000 => self.lcd_registers.dispcnt.read().get_byte(0),
+            0x04000001 => self.lcd_registers.dispcnt.read().get_byte(1),
+            0x04000002 => self.lcd_registers.green_swap.read().get_byte(0),
+            0x04000003 => self.lcd_registers.green_swap.read().get_byte(1),
+            0x04000004 => self.lcd_registers.dispstat.read().get_byte(0),
+            0x04000005 => self.lcd_registers.dispstat.read().get_byte(1),
+            0x04000006 => self.lcd_registers.vcount.read().get_byte(0),
+            0x04000007 => self.lcd_registers.vcount.read().get_byte(1),
+            0x04000008 => self.lcd_registers.bg0cnt.read().get_byte(0),
+            0x04000009 => self.lcd_registers.bg0cnt.read().get_byte(1),
+            0x0400000A => self.lcd_registers.bg1cnt.read().get_byte(0),
+            0x0400000B => self.lcd_registers.bg1cnt.read().get_byte(1),
+            0x0400000C => self.lcd_registers.bg2cnt.read().get_byte(0),
+            0x0400000D => self.lcd_registers.bg2cnt.read().get_byte(1),
+            0x0400000E => self.lcd_registers.bg3cnt.read().get_byte(0),
+            0x0400000F => self.lcd_registers.bg3cnt.read().get_byte(1),
+            0x04000048 => self.lcd_registers.winin.read().get_byte(0),
+            0x04000049 => self.lcd_registers.winin.read().get_byte(1),
+            0x0400004A => self.lcd_registers.winout.read().get_byte(0),
+            0x0400004B => self.lcd_registers.winout.read().get_byte(1),
+            0x04000050 => self.lcd_registers.bldcnt.read().get_byte(0),
+            0x04000051 => self.lcd_registers.bldcnt.read().get_byte(1),
+            0x04000052 => self.lcd_registers.bldalpha.read().get_byte(0),
+            0x04000053 => self.lcd_registers.bldalpha.read().get_byte(1),
+            _ => panic!("Reading an write-only memory address: {address:b}"),
         }
     }
 }
@@ -18,12 +148,73 @@ impl IoDevice for InternalMemory {
     type Value = u8;
 
     fn read_at(&self, address: Self::Address) -> Self::Value {
-        let a: usize = address.try_into().unwrap();
-        self.internal_work_ram[a]
+        match address {
+            0x03000000..=0x03007FFF => self.internal_work_ram[address as usize],
+            0x04000000..=0x04000055 => self.read_address_lcd_register(address),
+            _ => unimplemented!("Unimplemented memory region."),
+        }
     }
 
     fn write_at(&mut self, address: Self::Address, value: Self::Value) {
-        let a: usize = address.try_into().unwrap();
-        self.internal_work_ram[a] = value;
+        match address {
+            0x03000000..=0x03007FFF => {
+                self.internal_work_ram[address as usize] = value
+            }
+            0x04000000..=0x04000055 => self.write_address_lcd_register(address, value),
+            _ => unimplemented!("Unimplemented memory region."),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_write_work_ram() {
+        let mut im = InternalMemory::new();
+
+        let address = 0x03000005;
+        im.write_at(address, 5);
+
+        assert_eq!(im.internal_work_ram[5], 5);
+    }
+
+    #[test]
+    fn test_read_work_ram() {
+        let mut im = InternalMemory::new();
+        im.internal_work_ram[5] = 10;
+
+        let address = 0x03000005;
+        assert_eq!(im.read_at(address), 10);
+    }
+
+    #[test]
+    fn test_write_lcd_reg() {
+        let mut im = InternalMemory::new();
+        let address = 0x04000048; // WININ lower byte
+
+        im.write_at(address, 10);
+
+        assert_eq!(im.lcd_registers.winin.read(), 10);
+
+        let address = 0x04000049; // WININ higher byte
+
+        im.write_at(address, 5);
+        assert_eq!(im.lcd_registers.winin.read(), (5 << 8) | 10);
+    }
+
+    #[test]
+    fn test_read_lcd_reg() {
+        let mut im = InternalMemory::new();
+        let address = 0x04000048; // WININ lower byte
+
+        im.lcd_registers.winin.write((5 << 8) | 10);
+
+        assert_eq!(im.read_at(address), 10);
+
+        let address = 0x04000049; // WININ higher byte
+
+        assert_eq!(im.read_at(address), 5);
     }
 }

--- a/emu/src/io_registers.rs
+++ b/emu/src/io_registers.rs
@@ -1,0 +1,221 @@
+use crate::bitwise::Bits;
+
+pub enum IORegisterAccessControl {
+    Read,
+    Write,
+    ReadWrite,
+}
+
+pub struct IORegister {
+    value: u32,
+    access: IORegisterAccessControl,
+}
+
+impl IORegister {
+    pub fn read(&self) -> u32 {
+        match self.access {
+            IORegisterAccessControl::Read | IORegisterAccessControl::ReadWrite => self.value,
+            _ => panic!("Requested IO Register cannot be read."),
+        }
+    }
+
+    pub fn write(&mut self, value: u32) {
+        match self.access {
+            IORegisterAccessControl::Write | IORegisterAccessControl::ReadWrite => {
+                self.value = value;
+            }
+
+            _ => panic!("Requested IO Register cannot be written."),
+        }
+    }
+
+    pub fn set_byte(&mut self, byte: u8, value: u8) {
+        match self.access {
+            IORegisterAccessControl::Write | IORegisterAccessControl::ReadWrite => {
+                self.value.set_byte(byte, value);
+            }
+
+            _ => panic!("Requested IO Register cannot be written."),
+        }
+    }
+
+    pub const fn with_access_control(access: IORegisterAccessControl) -> Self {
+        Self { value: 0, access }
+    }
+}
+
+pub struct LCDRegisters {
+    /// LCD Control
+    pub dispcnt: IORegister,
+    /// Undocumented - Green Swap
+    pub green_swap: IORegister,
+    /// General LCD Status (STAT, LYC)
+    pub dispstat: IORegister,
+    /// Vertical Counter (LY)
+    pub vcount: IORegister,
+    /// BG0 Control
+    pub bg0cnt: IORegister,
+    /// BG1 Control
+    pub bg1cnt: IORegister,
+    /// BG2 Control
+    pub bg2cnt: IORegister,
+    /// BG3 Control
+    pub bg3cnt: IORegister,
+    /// BG0 X-Offset
+    pub bg0hofs: IORegister,
+    /// BG0 Y_Offset
+    pub bg0vofs: IORegister,
+    /// BG1 X-Offset
+    pub bg1hofs: IORegister,
+    /// BG1 Y_Offset
+    pub bg1vofs: IORegister,
+    /// BG2 X-Offset
+    pub bg2hofs: IORegister,
+    /// BG2 Y_Offset
+    pub bg2vofs: IORegister,
+    /// BG3 X-Offset
+    pub bg3hofs: IORegister,
+    /// BG3 Y_Offset
+    pub bg3vofs: IORegister,
+    /// BG2 Rotation/Scaling Parameter A (dx)
+    pub bg2pa: IORegister,
+    /// BG2 Rotation/Scaling Parameter B (dmx)
+    pub bg2pb: IORegister,
+    /// BG2 Rotation/Scaling Parameter C (dy)
+    pub bg2pc: IORegister,
+    /// BG2 Rotation/Scaling Parameter D (dmy)
+    pub bg2pd: IORegister,
+    /// BG2 Reference Point X-Coordinate
+    pub bg2x: IORegister,
+    /// BG2 Reference Point Y-Coordinate
+    pub bg2y: IORegister,
+    /// BG3 Rotation/Scaling Parameter A (dx)
+    pub bg3pa: IORegister,
+    /// BG3 Rotation/Scaling Parameter B (dmx)
+    pub bg3pb: IORegister,
+    /// BG3 Rotation/Scaling Parameter C (dy)
+    pub bg3pc: IORegister,
+    /// BG3 Rotation/Scaling Parameter D (dmy)
+    pub bg3pd: IORegister,
+    /// BG3 Reference Point X-Coordinate
+    pub bg3x: IORegister,
+    /// BG3 Reference Point Y-Coordinate
+    pub bg3y: IORegister,
+    /// Window 0 Horizontal Dimensions
+    pub win0h: IORegister,
+    /// Window 1 Horizontal Dimensions
+    pub win1h: IORegister,
+    /// Window 0 Vertical Dimensions
+    pub win0v: IORegister,
+    /// Window 1 Vertical Dimensions
+    pub win1v: IORegister,
+    /// Inside of Window 0 and 1
+    pub winin: IORegister,
+    /// Inside of OBJ Window & Outside of Windows
+    pub winout: IORegister,
+    /// Mosaic Size
+    pub mosaic: IORegister,
+    /// Color Special Effects Selection
+    pub bldcnt: IORegister,
+    /// Alpha Blending Coefficients
+    pub bldalpha: IORegister,
+    /// Brightness (Fade-In/Out) Coefficient
+    pub bldy: IORegister,
+}
+
+impl Default for LCDRegisters {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LCDRegisters {
+    pub const fn new() -> Self {
+        use IORegisterAccessControl::*;
+
+        Self {
+            dispcnt: IORegister::with_access_control(ReadWrite),
+            green_swap: IORegister::with_access_control(ReadWrite),
+            dispstat: IORegister::with_access_control(ReadWrite),
+            vcount: IORegister::with_access_control(Read),
+            bg0cnt: IORegister::with_access_control(ReadWrite),
+            bg1cnt: IORegister::with_access_control(ReadWrite),
+            bg2cnt: IORegister::with_access_control(ReadWrite),
+            bg3cnt: IORegister::with_access_control(ReadWrite),
+            bg0hofs: IORegister::with_access_control(Write),
+            bg0vofs: IORegister::with_access_control(Write),
+            bg1hofs: IORegister::with_access_control(Write),
+            bg1vofs: IORegister::with_access_control(Write),
+            bg2hofs: IORegister::with_access_control(Write),
+            bg2vofs: IORegister::with_access_control(Write),
+            bg3hofs: IORegister::with_access_control(Write),
+            bg3vofs: IORegister::with_access_control(Write),
+            bg2pa: IORegister::with_access_control(Write),
+            bg2pb: IORegister::with_access_control(Write),
+            bg2pc: IORegister::with_access_control(Write),
+            bg2pd: IORegister::with_access_control(Write),
+            bg2x: IORegister::with_access_control(Write),
+            bg2y: IORegister::with_access_control(Write),
+            bg3pa: IORegister::with_access_control(Write),
+            bg3pb: IORegister::with_access_control(Write),
+            bg3pc: IORegister::with_access_control(Write),
+            bg3pd: IORegister::with_access_control(Write),
+            bg3x: IORegister::with_access_control(Write),
+            bg3y: IORegister::with_access_control(Write),
+            win0h: IORegister::with_access_control(Write),
+            win1h: IORegister::with_access_control(Write),
+            win0v: IORegister::with_access_control(Write),
+            win1v: IORegister::with_access_control(Write),
+            winin: IORegister::with_access_control(ReadWrite),
+            winout: IORegister::with_access_control(ReadWrite),
+            mosaic: IORegister::with_access_control(Write),
+            bldcnt: IORegister::with_access_control(ReadWrite),
+            bldalpha: IORegister::with_access_control(ReadWrite),
+            bldy: IORegister::with_access_control(Write),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use IORegisterAccessControl::*;
+    #[test]
+    #[should_panic]
+    fn write_only_register() {
+        let reg = IORegister::with_access_control(Write);
+
+        reg.read();
+    }
+
+    #[test]
+    #[should_panic]
+    fn read_only_register_write() {
+        let mut reg = IORegister::with_access_control(Read);
+
+        reg.write(5);
+    }
+
+    #[test]
+    #[should_panic]
+    fn read_only_register_set_byte() {
+        let mut reg = IORegister::with_access_control(Read);
+
+        reg.set_byte(3, 4);
+    }
+
+    #[test]
+    fn test_ioregister() {
+        let mut reg = IORegister::with_access_control(ReadWrite);
+
+        assert_eq!(reg.read(), 0);
+
+        reg.write(5);
+
+        assert_eq!(reg.read(), 5);
+
+        reg.set_byte(1, 3);
+
+        assert_eq!(reg.read(), (3 << 8) | 5);
+    }
+}

--- a/emu/src/lib.rs
+++ b/emu/src/lib.rs
@@ -9,5 +9,6 @@ pub mod gba;
 pub mod instruction;
 pub mod internal_memory;
 pub mod io_device;
+pub mod io_registers;
 pub mod opcode;
 pub mod ppu;


### PR DESCRIPTION
This PR adds `LCDRegisters` memory region to `InternalMemory`. It serves as preparation to implement the ppu (hopefully :D).

Structs `IORegister` and `LCDRegisters` have been written to model these registers.

Unit tests have been added to `InternalMemory`.

Added `get_byte` and `set_byte` in `Bits` trait to selectively read/write a specific byte from an `u32`.