### PR TITLE
ALU: Add `SUB`, `RSB`, `CMN` op and Fix `CMP`, `MOV` op

### DIFF
--- a/emu/src/arm7tdmi.rs
+++ b/emu/src/arm7tdmi.rs
@@ -267,6 +267,7 @@ impl Arm7tdmi {
             ArmModeAluInstruction::Add => self.add(rd.try_into().unwrap(), rn, op2, s),
             ArmModeAluInstruction::Orr => self.orr(rd.try_into().unwrap(), rn, op2, s),
             ArmModeAluInstruction::Sub => self.sub(rd.try_into().unwrap(), rn, op2, s),
+            ArmModeAluInstruction::Rsb => self.rsb(rd.try_into().unwrap(), rn, op2, s),
             _ => todo!("implement alu operation: {}", alu_op_code),
         }
     }
@@ -506,6 +507,10 @@ impl Arm7tdmi {
         }
     }
 
+    fn rsb(&mut self, rd: usize, rn: u32, op2: u32, s: bool) {
+        self.sub(rd, op2, rn, s);
+    }
+    
     fn shift_operand(
         &mut self,
         alu_opcode: u32,

--- a/emu/src/arm7tdmi.rs
+++ b/emu/src/arm7tdmi.rs
@@ -237,6 +237,12 @@ impl Arm7tdmi {
 
         let op2 = self.get_operand(alu_op_code, s, i, op_code.get_bits(0..=11));
 
+        // S = 1 and Rd = 0xF should not be allowed in User Mode.
+        // TODO: When in other modes it should load SPSR_<current_mode> into CPSR
+        if s && rd == 0xF {
+            unimplemented!("Implement cases when S=1 and Rd=0xF");
+        }
+
         match ArmModeAluInstruction::from(alu_op_code) {
             ArmModeAluInstruction::And => self.and(rd.try_into().unwrap(), rn, op2, s),
             ArmModeAluInstruction::Eor => self.eor(rd.try_into().unwrap(), rn, op2, s),

--- a/emu/src/arm7tdmi.rs
+++ b/emu/src/arm7tdmi.rs
@@ -264,6 +264,11 @@ impl Arm7tdmi {
                     self.cmp(rn, op2)
                 }
             }
+            ArmModeAluInstruction::Cmn => {
+                if s {
+                    self.cmn(rn, op2)
+                }
+            }
             ArmModeAluInstruction::Add => self.add(rd.try_into().unwrap(), rn, op2, s),
             ArmModeAluInstruction::Orr => self.orr(rd.try_into().unwrap(), rn, op2, s),
             ArmModeAluInstruction::Sub => self.sub(rd.try_into().unwrap(), rn, op2, s),
@@ -498,6 +503,12 @@ impl Arm7tdmi {
             sign: result.get_bit(31),
             zero: result == 0,
         }
+    }
+
+    fn cmn(&mut self, rn: u32, op2: u32) {
+        let add_result = Self::add_inner_op(rn, op2);
+
+        self.cpsr.set_flags(add_result);
     }
 
     fn cmp(&mut self, rn: u32, op2: u32) {

--- a/emu/src/arm7tdmi.rs
+++ b/emu/src/arm7tdmi.rs
@@ -492,9 +492,9 @@ impl Arm7tdmi {
     }
 
     fn cmp(&mut self, rn: u32, op2: u32) {
-        let value = rn - op2;
-        self.cpsr.set_sign_flag(value.is_bit_on(31));
-        self.cpsr.set_zero_flag(value == 0);
+        let sub_result = Self::sub_inner_op(rn, op2);
+
+        self.cpsr.set_flags(sub_result);
     }
 
     fn sub(&mut self, rd: usize, rn: u32, op2: u32, s: bool) {
@@ -510,7 +510,7 @@ impl Arm7tdmi {
     fn rsb(&mut self, rd: usize, rn: u32, op2: u32, s: bool) {
         self.sub(rd, op2, rn, s);
     }
-    
+
     fn shift_operand(
         &mut self,
         alu_opcode: u32,

--- a/emu/src/cpsr.rs
+++ b/emu/src/cpsr.rs
@@ -1,3 +1,4 @@
+use crate::arm7tdmi::ArithmeticOpResult;
 #[cfg(test)] // TODO: remove cfg when this API will be used at least one in prod code.
 use crate::condition::ModeBits;
 use crate::{bitwise::Bits, condition::Condition};
@@ -108,6 +109,13 @@ impl Cpsr {
 
     pub fn set_carry_flag(&mut self, value: bool) {
         self.0.set_bit(29, value);
+    }
+
+    pub fn set_flags(&mut self, op_result: ArithmeticOpResult) {
+        self.set_carry_flag(op_result.carry);
+        self.set_zero_flag(op_result.zero);
+        self.set_sign_flag(op_result.sign);
+        self.set_overflow_flag(op_result.overflow);
     }
 
     #[allow(dead_code)] // TODO: remove allow when this API will be used at least one in prod code.


### PR DESCRIPTION
* Add support for `SUB`, `RSB` and `CMN` ALU op
* Fix the `CMP` op: it was not executing all the sub logic (overflow/carry check, etc.)
* Fix `MOV` op: it was not setting the `CPSR` flags
* Extracted the add and sub logic to two separate functions since they are used in many operations (`SUB` and `CMP`, `ADD` and `CMN`) and there will be more with the same logic: `ADC`, `SBC`, `RSC`. I created a new struct to return the result of an arithmetic operation.