### PR TITLE
UI: Add `MemoryInspector`

### DIFF
--- a/emu/src/arm7tdmi.rs
+++ b/emu/src/arm7tdmi.rs
@@ -1,4 +1,4 @@
-use std::cell::RefCell;
+use std::cell::{Ref, RefCell};
 use std::convert::TryInto;
 use std::rc::Rc;
 
@@ -57,6 +57,7 @@ const OPCODE_ARM_SIZE: usize = 4;
 
 impl Cpu for Arm7tdmi {
     type OpCodeType = ArmModeOpcode;
+    type Memory = InternalMemory;
 
     fn fetch(&self) -> u32 {
         let instruction_index = self.registers.program_counter();
@@ -109,6 +110,10 @@ impl Cpu for Arm7tdmi {
 
     fn registers(&self) -> Vec<u32> {
         self.registers.to_vec()
+    }
+
+    fn get_memory(&self) -> Ref<'_, InternalMemory> {
+        self.memory.borrow()
     }
 }
 

--- a/emu/src/cpu.rs
+++ b/emu/src/cpu.rs
@@ -1,6 +1,11 @@
+use std::cell::Ref;
+
+use crate::memory::io_device::IoDevice;
+
 pub trait Cpu {
     /// Size of Opcode: it can be changed
     type OpCodeType;
+    type Memory: IoDevice<Address = u32, Value = u8>;
 
     /// It generally takes the next instruction from PC
     fn fetch(&self) -> u32;
@@ -17,4 +22,6 @@ pub trait Cpu {
 
     /// Get the value of all registers
     fn registers(&self) -> Vec<u32>;
+
+    fn get_memory(&self) -> Ref<'_, Self::Memory>;
 }

--- a/ui/src/dashboard.rs
+++ b/ui/src/dashboard.rs
@@ -3,7 +3,10 @@ use emu::{arm7tdmi::Arm7tdmi, cartridge_header::CartridgeHeader, gba::Gba};
 
 use super::about::About;
 use super::cpu_inspector::CpuInspector;
-use crate::{gba_display::GbaDisplay, palette_visualizer::PaletteVisualizer, ui_traits::UiTool};
+use crate::{
+    gba_display::GbaDisplay, memory_inspector::MemoryInspector,
+    palette_visualizer::PaletteVisualizer, ui_traits::UiTool,
+};
 
 use std::{
     collections::BTreeSet,
@@ -40,7 +43,8 @@ impl UiTools {
             Box::new(About::default()),
             Box::new(CpuInspector::new(arc_gba.clone())),
             Box::new(GbaDisplay::new(arc_gba.clone())),
-            Box::new(PaletteVisualizer::new(arc_gba)),
+            Box::new(PaletteVisualizer::new(arc_gba.clone())),
+            Box::new(MemoryInspector::new(arc_gba)),
         ])
     }
 
@@ -51,6 +55,7 @@ impl UiTools {
         open.insert(tools[1].name().to_owned());
         open.insert(tools[2].name().to_owned());
         open.insert(tools[3].name().to_owned());
+        open.insert(tools[4].name().to_owned());
 
         Self { tools, open }
     }

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -3,5 +3,6 @@ pub mod app;
 pub mod cpu_inspector;
 pub mod dashboard;
 pub mod gba_display;
+pub mod memory_inspector;
 pub mod palette_visualizer;
 pub mod ui_traits;

--- a/ui/src/memory_inspector.rs
+++ b/ui/src/memory_inspector.rs
@@ -1,0 +1,73 @@
+use emu::{cpu::Cpu, gba::Gba, memory::io_device::IoDevice};
+
+use crate::ui_traits::{UiTool, View};
+
+use std::{
+    borrow::Borrow,
+    sync::{Arc, Mutex},
+};
+
+pub struct MemoryInspector<T: Cpu> {
+    address_string: String,
+    value: u8,
+    base: Base,
+    gba: Arc<Mutex<Gba<T>>>,
+}
+
+impl<T: Cpu> MemoryInspector<T> {
+    pub fn new(gba: Arc<Mutex<Gba<T>>>) -> Self {
+        Self {
+            gba,
+            address_string: String::from("0"),
+            value: 0,
+            base: Base::Dec,
+        }
+    }
+}
+
+impl<T: Cpu> UiTool for MemoryInspector<T> {
+    fn name(&self) -> &'static str {
+        "Memory Inspector"
+    }
+
+    fn show(&mut self, ctx: &egui::Context, open: &mut bool) {
+        egui::Window::new(self.name())
+            .default_width(320.0)
+            .open(open)
+            .show(ctx, |ui| {
+                use View as _;
+                self.ui(ui);
+            });
+    }
+}
+
+#[derive(PartialEq)]
+enum Base {
+    Dec,
+    Hex,
+}
+
+impl<T: Cpu> View for MemoryInspector<T> {
+    fn ui(&mut self, ui: &mut egui::Ui) {
+        ui.radio_value(&mut self.base, Base::Dec, "Dec");
+        ui.radio_value(&mut self.base, Base::Hex, "Hex");
+
+        ui.horizontal(|ui| {
+            ui.label("Memory address:");
+            ui.text_edit_singleline(&mut self.address_string);
+            if ui.button("Read").clicked() {
+                if let Ok(gba) = self.gba.lock() {
+                    let radix = match self.base {
+                        Base::Dec => 10,
+                        Base::Hex => 16,
+                    };
+
+                    let address = u32::from_str_radix(&self.address_string, radix).unwrap();
+                    self.value = gba.borrow().cpu.get_memory().borrow().read_at(address);
+                }
+            }
+        });
+
+        ui.label(format!("Value: {}", self.value));
+    }
+}


### PR DESCRIPTION
Added a new UiTool to read values from memory.

I don't like very much how it is implemented but it was the only way (or at least the only one I found) to make it work since we have `Gba<T: Cpu>` and `Cpu` trait didn't have any method to access memory and memory is stored into an `Rc<RefCell<>>`.

Please tell me if you think it could be implemented in a better way (maybe without returning `Ref`? But I think it's needed since `InternalMemory` is managed by a `RefCell`).

It's very simple because I want to use it to debug an issue we may have in the instruction implementations. In the future, we could show a matrix with all the values and so on but for now I think this does the job.