### PR TITLE
Fix block data transfer

### DIFF
--- a/emu/src/arm7tdmi.rs
+++ b/emu/src/arm7tdmi.rs
@@ -168,7 +168,13 @@ impl Arm7tdmi {
             self.exec_data_trasfer(reg_list, pre_post, &mut address, up_down, transfer);
         } else {
             let transfer = |arm: &mut Self, address: u32, reg_source: usize| {
-                let value = arm.registers.register_at(reg_source);
+                let mut value = arm.registers.register_at(reg_source);
+
+                // If R15 we get the value of the current instruction + 12
+                if reg_source == 0xF {
+                    value += 12;
+                }
+
                 arm.memory
                     .borrow_mut()
                     .write_at(address, value.get_bits(0..=7) as u8);

--- a/emu/src/single_data_transfer.rs
+++ b/emu/src/single_data_transfer.rs
@@ -123,7 +123,13 @@ impl Arm7tdmi {
             SingleDataTransfer::Str => match byte_or_word {
                 ReadWriteKind::Byte => self.memory.borrow_mut().write_at(address, rd as u8),
                 ReadWriteKind::Word => {
-                    let v = self.registers.register_at(rd.try_into().unwrap());
+                    let mut v = self.registers.register_at(rd.try_into().unwrap());
+
+                    // If R15 we get the value of the current instruction + 12
+                    if rd == 0xF {
+                        v += 12;
+                    }
+
                     self.memory
                         .borrow_mut()
                         .write_at(address, v.get_bits(0..=7) as u8);


### PR DESCRIPTION
* Now correctly adds `12` when storing `R15 (PC)`
* Inverts iteration order when using decrementing. From documentation:
> The lowest register also gets transferred to/from the lowest memory address
So we should invert the order when decrementing otherwise we would store/save in inverse order.