### PR TITLE
Fix advance cond

### DIFF
--- a/emu/src/arm7tdmi.rs
+++ b/emu/src/arm7tdmi.rs
@@ -104,6 +104,8 @@ impl Cpu for Arm7tdmi {
         let op_code = self.decode(op_code);
         if self.cpsr.can_execute(op_code.condition) {
             self.execute(op_code)
+        } else {
+            self.registers.advance_program_counter(4);
         }
     }
 

--- a/emu/src/opcode.rs
+++ b/emu/src/opcode.rs
@@ -132,7 +132,7 @@ impl Display for ArmModeOpcode {
         };
 
         let mut raw_bits = String::new();
-        for i in format!("{:b}", self.raw).chars() {
+        for i in format!("{:#034b}", self.raw).chars().skip(2) {
             raw_bits.push(i);
             raw_bits.push('_');
         }


### PR DESCRIPTION
* When the instruction can't be executed because of cond flags, the program counter should be increased instead of staying on the same instruction forever
* When printing the instruction, we should pad with leading zeroes otherwise it would not print 32 bits when `cond` starts with 0.