### PR TITLE
Add new logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "arboard"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -199,6 +208,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-integer",
+ "num-traits",
+ "time",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
 name = "clementine"
 version = "0.1.0"
 dependencies = [
@@ -206,6 +230,7 @@ dependencies = [
  "egui",
  "egui_glium",
  "emu",
+ "logger",
  "pretty_assertions",
  "rand",
  "ui",
@@ -260,6 +285,16 @@ dependencies = [
  "foreign-types 0.3.2",
  "libc",
  "objc",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
 ]
 
 [[package]]
@@ -427,6 +462,50 @@ name = "cty"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
+
+[[package]]
+name = "cxx"
+version = "1.0.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97abf9f0eca9e52b7f81b945524e76710e6cb2366aead23b7d4fbf72e281f888"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cc32cc5fea1d894b77d269ddb9f192110069a8a9c1f1d441195fba90553dea3"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca220e4794c934dc6b1207c3b42856ad4c302f2df1712e9f8d2eec5afaacf1f"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b846f081361125bfc8dc9d3940c84e1fd83ba54bbca7b17cd29483c828be0704"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "darling"
@@ -603,6 +682,7 @@ dependencies = [
 name = "emu"
 version = "0.1.0"
 dependencies = [
+ "logger",
  "pretty_assertions",
  "rand",
 ]
@@ -790,7 +870,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -933,6 +1013,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1053,6 +1157,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "link-cplusplus"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,6 +1182,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "logger"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "once_cell",
 ]
 
 [[package]]
@@ -1142,7 +1263,7 @@ checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
 ]
 
@@ -1157,26 +1278,13 @@ dependencies = [
 
 [[package]]
 name = "ndk"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2032c77e030ddee34a6787a64166008da93f6a352b629261d0fee232b8742dd4"
-dependencies = [
- "bitflags",
- "jni-sys",
- "ndk-sys 0.3.0",
- "num_enum",
- "thiserror",
-]
-
-[[package]]
-name = "ndk"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "451422b7e4718271c8b5b3aadf5adedba43dc76312454b387e98fae0fc951aa0"
 dependencies = [
  "bitflags",
  "jni-sys",
- "ndk-sys 0.4.0",
+ "ndk-sys",
  "num_enum",
  "raw-window-handle 0.5.0",
  "thiserror",
@@ -1190,31 +1298,16 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "ndk-glue"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d0c4a7b83860226e6b4183edac21851f05d5a51756e97a1144b7f5a6b63e65f"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "ndk 0.6.0",
- "ndk-context",
- "ndk-macro",
- "ndk-sys 0.3.0",
-]
-
-[[package]]
-name = "ndk-glue"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0434fabdd2c15e0aab768ca31d5b7b333717f03cf02037d5a0a3ff3c278ed67f"
 dependencies = [
  "libc",
  "log",
- "ndk 0.7.0",
+ "ndk",
  "ndk-context",
  "ndk-macro",
- "ndk-sys 0.4.0",
+ "ndk-sys",
  "once_cell",
  "parking_lot",
 ]
@@ -1230,15 +1323,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "ndk-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e5a6ae77c8ee183dcbbba6150e2e6b9f3f4196a7666c02a715a95692ec1fa97"
-dependencies = [
- "jni-sys",
 ]
 
 [[package]]
@@ -1379,9 +1463,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.14.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "osmesa-sys"
@@ -1654,6 +1738,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "scratch"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+
+[[package]]
 name = "sctk-adwaita"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1796,6 +1886,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36ae8932fcfea38b7d3883ae2ab357b0d57a02caaa18ebb4f5ece08beaec4aa0"
 
 [[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1833,6 +1932,17 @@ dependencies = [
  "flate2",
  "jpeg-decoder",
  "weezl",
+]
+
+[[package]]
+name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
 ]
 
 [[package]]
@@ -1919,6 +2029,7 @@ dependencies = [
  "egui_extras",
  "emu",
  "image",
+ "logger",
 ]
 
 [[package]]
@@ -1941,6 +2052,12 @@ checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "url"
@@ -1976,6 +2093,12 @@ dependencies = [
  "winapi",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -2149,7 +2272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01d62aa75495ab67cdc273d0b95cc76bcedfea2ba28338a4cf9b4137949dfac5"
 dependencies = [
  "jni",
- "ndk-glue 0.6.2",
+ "ndk-glue",
  "objc",
  "raw-window-handle 0.5.0",
  "url",
@@ -2268,8 +2391,8 @@ dependencies = [
  "libc",
  "log",
  "mio",
- "ndk 0.7.0",
- "ndk-glue 0.7.0",
+ "ndk",
+ "ndk-glue",
  "objc",
  "once_cell",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "clementine"
 version = "0.1.0"
 
 [workspace]
-members = ["emu", "ui"]
+members = ["emu", "ui", "logger"]
 
 [workspace.package]
 readme = "./README.md"
@@ -19,6 +19,7 @@ egui_glium = { version = "0.19.0", git = "https://github.com/emilk/egui/" }
 
 emu = { path = "./emu" }
 ui = { path  = "./ui" }
+logger = { path = "./logger" }
 
 [dev-dependencies]
 pretty_assertions = "1.3.0"

--- a/emu/Cargo.toml
+++ b/emu/Cargo.toml
@@ -6,6 +6,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
+logger = { path = "../logger" }
 rand = { version = "0.8.5", optional = true}
 
 [dev-dependencies]

--- a/emu/src/arm7tdmi.rs
+++ b/emu/src/arm7tdmi.rs
@@ -1,6 +1,8 @@
 use std::convert::TryInto;
 use std::sync::{Arc, Mutex};
 
+use logger::log;
+
 use crate::bitwise::Bits;
 use crate::instruction::ArmModeInstruction;
 use crate::memory::internal_memory::InternalMemory;
@@ -67,7 +69,7 @@ impl Cpu for Arm7tdmi {
 
     fn decode(&self, op_code: u32) -> Self::OpCodeType {
         let op_code = ArmModeOpcode::try_from(op_code).unwrap();
-        println!("{}", op_code);
+        log(format!("{op_code}"));
         if op_code.instruction == ArmModeInstruction::Unknown {
             todo!("implement this instruction")
         }

--- a/emu/src/instruction.rs
+++ b/emu/src/instruction.rs
@@ -1,5 +1,7 @@
 use std::fmt::{Display, Formatter};
 
+use logger::log;
+
 #[derive(Debug, PartialEq, Eq)]
 pub enum ArmModeInstruction {
     DataProcessing1 = 0b0000_0000_0000_0000_0000_0000_0000_0000,
@@ -31,7 +33,7 @@ impl From<u32> for ArmModeInstruction {
         } else if Self::check(BlockDataTransfer, op_code) {
             BlockDataTransfer
         } else {
-            println!("{op_code:b}");
+            log(format!("{op_code:b}"));
             Unknown
         }
     }

--- a/logger/Cargo.toml
+++ b/logger/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "logger"
+version = "0.1.0"
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+
+[dependencies]
+chrono = "0.4.22"
+once_cell = "1.16.0"

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -1,0 +1,135 @@
+use std::{
+    fs::File,
+    io::{self, Write},
+    sync::Mutex,
+    time::Instant,
+};
+
+use chrono::Utc;
+use once_cell::sync::OnceCell;
+
+static LOGGER: OnceCell<Logger> = OnceCell::new();
+
+struct LoggerImpl {
+    pub sink: Box<dyn Write + Send>,
+    pub start_instant: Instant,
+}
+
+impl LoggerImpl {
+    fn new(kind: LogKind) -> Self {
+        let start_instant = Instant::now();
+        match kind {
+            LogKind::STDOUT => Self {
+                sink: Box::new(io::stdout()),
+                start_instant,
+            },
+            LogKind::FILE => {
+                let now = Utc::now();
+                let filename = format!("clementine-{}.log", now.timestamp());
+                let path = std::env::temp_dir().join(filename);
+                Self {
+                    sink: Box::new(File::create(path).unwrap()),
+                    start_instant,
+                }
+            }
+        }
+    }
+
+    fn log<T>(&mut self, data: T)
+    where
+        T: std::fmt::Display,
+    {
+        let now = self.start_instant.elapsed();
+        let seconds = now.as_secs();
+        let hours = seconds / 3600;
+        let minutes = (seconds / 60) % 60;
+        let seconds = seconds % 60;
+        let miliseconds = now.subsec_millis();
+
+        let _ = writeln!(
+            self.sink,
+            "[{:02}:{:02}:{:02}.{:03}] {}",
+            hours, minutes, seconds, miliseconds, data
+        );
+    }
+}
+
+/// LogKind represents the kind of logging: `stdout` or `logfile`.
+#[derive(PartialEq, Eq)]
+pub enum LogKind {
+    /// It logs to console, the default choice.
+    STDOUT,
+
+    /// It logs on a file in /tmp/clementine-<timestamp>.log
+    FILE,
+}
+
+/// Logger
+struct Logger {
+    pub inner_impl: Mutex<LoggerImpl>,
+}
+
+impl Default for Logger {
+    fn default() -> Self {
+        Self {
+            inner_impl: Mutex::new(LoggerImpl::new(LogKind::STDOUT)),
+        }
+    }
+}
+
+impl Logger {
+    fn new(kind: LogKind) -> Self {
+        Self {
+            inner_impl: Mutex::new(LoggerImpl::new(kind)),
+        }
+    }
+
+    fn log<T>(&self, data: T)
+    where
+        T: std::fmt::Display,
+    {
+        if let Ok(ref mut inner) = self.inner_impl.lock() {
+            inner.log(data);
+        }
+    }
+}
+
+pub fn init_logger(kind: LogKind) {
+    _ = LOGGER.set(Logger::new(kind));
+}
+
+pub fn log<T>(data: T)
+where
+    T: std::fmt::Display,
+{
+    LOGGER.get().map_or((), |logger| logger.log(data));
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use crate::{init_logger, log, LogKind};
+
+    #[test]
+    fn logger_file() {
+        init_logger(LogKind::FILE);
+        log("ok".to_string());
+        let dir = std::env::temp_dir();
+        let files = fs::read_dir(dir).unwrap();
+        for f in files {
+            if let Ok(ff) = f {
+                let p = ff.path();
+                if let Some(ext) = p.extension() {
+                    let s = p.to_str().unwrap();
+                    if ext == "log" && s.contains(&"clementine") {
+                        print!("{p:?}");
+                        let s = fs::read_to_string(p.clone()).unwrap();
+                        fs::remove_file(p).unwrap();
+                        assert_eq!(s, "[00:00:00.000] ok\n".to_string());
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,19 +1,33 @@
-use std::env;
+use std::{env, process};
 extern crate ui;
 use ui::app::ClementineApp;
+extern crate logger;
+use logger::{init_logger, log, LogKind};
 
 fn main() {
-    println!("clementine v0.1.0");
+    let mut args = env::args().skip(1).collect::<Vec<String>>();
 
-    let args = env::args().skip(1).collect::<Vec<String>>();
+    if args.len() > 1 {
+        let arg = args.remove(0);
+        if arg.as_str() == "--log-on-file" {
+            init_logger(LogKind::FILE);
+        } else {
+            eprintln!("arguments not recognized.");
+            process::exit(1);
+        }
+    } else {
+        init_logger(LogKind::STDOUT);
+    }
+
+    log("clementine v0.1.0");
 
     let cartridge_name = args.first().map_or_else(
         || {
-            println!("no cartridge found :(");
+            log("no cartridge found :(");
             std::process::exit(1)
         },
         |name| {
-            println!("loading {name}");
+            log("loading {name}");
             name.clone()
         },
     );

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -6,6 +6,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
+logger = { path = "../logger" }
 eframe = { version = "0.19.0", git = "https://github.com/emilk/egui", default-features = false, features = ["glow"] }
 egui = { version = "0.19.0", git = "https://github.com/emilk/egui", default-features = false }
 egui_extras = { version = "0.19.0", git = "https://github.com/emilk/egui", features = ["image"] }

--- a/ui/src/dashboard.rs
+++ b/ui/src/dashboard.rs
@@ -1,5 +1,6 @@
 use egui::Context;
 use emu::{cartridge_header::CartridgeHeader, gba::Gba};
+use logger::log;
 
 use super::about::About;
 use super::cpu_inspector::CpuInspector;
@@ -24,7 +25,7 @@ impl UiTools {
         let data = match read_file(&cartridge_name) {
             Ok(d) => d,
             Err(e) => {
-                println!("{e}");
+                log(format!("{e}"));
                 std::process::exit(2);
             }
         };


### PR DESCRIPTION
- Logger: Add new logger for `clementine`
- Everywhere: Use logger in the code with a special arg `--log-on-file`

Basically the feature is because I would love to analyze the data and istruction post-run of a specific ROM, since now we have enough instruction running but we don't know where are bugs :).
This allow us to log on stdout as befor of log on a file saved under `/tmp/clementine-{utc::now()}.log` with a special arg like `./clementine --log-on-file my_game.gba`.

We need to check this path on windows platform.
