### PR TITLE
ARM: Improve decode instruction from op_code (u32)

### DIFF
--- a/emu/src/arm7tdmi.rs
+++ b/emu/src/arm7tdmi.rs
@@ -88,7 +88,7 @@ impl Cpu for Arm7tdmi {
             SingleDataTransfer => self.single_data_transfer(op_code),
             Undefined => todo!(),
             BlockDataTransfer => self.block_data_transfer(op_code),
-            Branch => self.branch(op_code, true), // FIXME: Handle link inside this function.
+            Branch => self.branch(op_code),
             CoprocessorDataTransfer => todo!(),
             CoprocessorDataOperation => todo!(),
             CoprocessorRegisterTrasfer => todo!(),
@@ -122,7 +122,7 @@ impl Arm7tdmi {
         }
     }
 
-    fn branch(&mut self, op_code: ArmModeOpcode, link: bool) -> bool {
+    fn branch(&mut self, op_code: ArmModeOpcode) -> bool {
         let offset = op_code.get_bits(0..=23) << 2;
 
         // We need to sign-extend the 26 bit number into a 32 bit.
@@ -133,7 +133,8 @@ impl Arm7tdmi {
         let offset = (offset as i32 ^ mask) - mask;
 
         let old_pc: u32 = self.registers.program_counter().try_into().unwrap();
-        if link {
+        let is_link = op_code.get_bit(24);
+        if is_link {
             self.registers.set_register_at(14, old_pc.wrapping_add(4));
         }
 
@@ -248,7 +249,6 @@ impl Arm7tdmi {
 #[cfg(test)]
 mod tests {
     use crate::condition::Condition;
-    use crate::instruction::ArmModeInstruction;
     use pretty_assertions::assert_eq;
 
     use super::*;

--- a/emu/src/arm7tdmi.rs
+++ b/emu/src/arm7tdmi.rs
@@ -70,10 +70,6 @@ impl Cpu for Arm7tdmi {
     fn decode(&self, op_code: u32) -> Self::OpCodeType {
         let op_code = ArmModeOpcode::try_from(op_code).unwrap();
         log(format!("{op_code}"));
-        if op_code.instruction == ArmModeInstruction::Unknown {
-            todo!("implement this instruction")
-        }
-
         op_code
     }
 
@@ -82,14 +78,21 @@ impl Cpu for Arm7tdmi {
         // Instruction functions should return whether PC has to be advanced
         // after instruction executed.
         let should_advance_pc = match op_code.instruction {
-            Branch => self.branch(op_code, false),
-            BranchLink => self.branch(op_code, true),
-            DataProcessing1 | DataProcessing2 | DataProcessing3 => self.data_processing(op_code),
-            TransImm9 => self.single_data_transfer(op_code),
+            DataProcessing => self.data_processing(op_code),
+            Multiply => todo!(),
+            MultiplyLong => todo!(),
+            SingleDataSwap => todo!(),
+            BranchAndExchange => todo!(),
+            HalfwordDataTransferRegisterOffset => todo!(),
+            HalfwordDataTransferImmediateOffset => todo!(),
+            SingleDataTransfer => self.single_data_transfer(op_code),
+            Undefined => todo!(),
             BlockDataTransfer => self.block_data_transfer(op_code),
-            Unknown => {
-                todo!("implement this instruction")
-            }
+            Branch => self.branch(op_code, true), // FIXME: Handle link inside this function.
+            CoprocessorDataTransfer => todo!(),
+            CoprocessorDataOperation => todo!(),
+            CoprocessorRegisterTrasfer => todo!(),
+            SoftwareInterrupt => todo!(),
         };
 
         if should_advance_pc {
@@ -251,22 +254,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn decode_branch() {
-        let output: ArmModeOpcode = 0b1110_1010_0000_0000_0000_0000_0111_1111
-            .try_into()
-            .unwrap();
-        assert_eq!(output.instruction, ArmModeInstruction::Branch);
-    }
-
-    #[test]
-    fn decode_branch_link() {
-        let output: ArmModeOpcode = 0b1110_1011_0000_0000_0000_0000_0111_1111
-            .try_into()
-            .unwrap();
-        assert_eq!(output.instruction, ArmModeInstruction::BranchLink);
-    }
-
-    #[test]
     fn test_branch() {
         // Covers a positive offset
 
@@ -306,7 +293,6 @@ mod tests {
         let mut cpu = Arm7tdmi::default();
 
         let op_code = cpu.decode(op_code);
-        assert_eq!(op_code.instruction, ArmModeInstruction::Unknown);
         assert_eq!(op_code.condition, Condition::AL);
 
         cpu.execute(op_code);

--- a/emu/src/data_processing.rs
+++ b/emu/src/data_processing.rs
@@ -500,7 +500,7 @@ mod tests {
             let op_code = 0b1110_0001_0010_1001_0011_0000_0000_0000;
             let mut cpu = Arm7tdmi::default();
             let op_code = cpu.decode(op_code);
-            assert_eq!(op_code.instruction, ArmModeInstruction::DataProcessing1);
+            assert_eq!(op_code.instruction, ArmModeInstruction::DataProcessing);
             let rn = 9_usize;
             cpu.registers.set_register_at(rn, 100);
             cpu.cpsr.set_sign_flag(true); // set for later verify.
@@ -515,7 +515,7 @@ mod tests {
         let op_code: u32 = 0b1110_0001_0011_1010_0011_0000_0000_0000;
         let mut cpu = Arm7tdmi::default();
         let op_code = cpu.decode(op_code);
-        assert_eq!(op_code.instruction, ArmModeInstruction::DataProcessing1);
+        assert_eq!(op_code.instruction, ArmModeInstruction::DataProcessing);
         let rn = 9_usize;
         cpu.registers.set_register_at(rn, 1);
         cpu.execute(op_code);
@@ -528,7 +528,7 @@ mod tests {
         let op_code: u32 = 0b1110_0001_0010_1010_0011_0000_0000_0000;
         let mut cpu = Arm7tdmi::default();
         let op_code = cpu.decode(op_code);
-        assert_eq!(op_code.instruction, ArmModeInstruction::DataProcessing1);
+        assert_eq!(op_code.instruction, ArmModeInstruction::DataProcessing);
         let rn = 9_usize;
         cpu.registers.set_register_at(rn, 1);
         cpu.cpsr.set_sign_flag(true); // set for later verify.
@@ -542,7 +542,7 @@ mod tests {
         let op_code = 0b1110_0010_1000_1111_0000_0000_0010_0000;
         let mut cpu = Arm7tdmi::default();
         let op_code = cpu.decode(op_code);
-        assert_eq!(op_code.instruction, ArmModeInstruction::DataProcessing3);
+        assert_eq!(op_code.instruction, ArmModeInstruction::DataProcessing);
         cpu.registers.set_register_at(15, 15);
         cpu.execute(op_code);
         assert_eq!(cpu.registers.register_at(0), 15 + 8 + 32);
@@ -555,7 +555,7 @@ mod tests {
         let op_code = 0b1110_0000_1000_0001_0010_0011_0001_1111;
         let mut cpu = Arm7tdmi::default();
         let op_code = cpu.decode(op_code);
-        assert_eq!(op_code.instruction, ArmModeInstruction::DataProcessing2);
+        assert_eq!(op_code.instruction, ArmModeInstruction::DataProcessing);
 
         cpu.registers.set_register_at(2, 5);
         cpu.registers.set_register_at(1, 10);
@@ -573,7 +573,7 @@ mod tests {
         let mut cpu = Arm7tdmi::default();
         let op_code = cpu.decode(op_code);
 
-        assert_eq!(op_code.instruction, ArmModeInstruction::DataProcessing1);
+        assert_eq!(op_code.instruction, ArmModeInstruction::DataProcessing);
 
         cpu.registers.set_register_at(15, 1 << 31);
         cpu.registers.set_register_at(14, 1 << 31);
@@ -606,7 +606,7 @@ mod tests {
 
             let op_code = cpu.decode(op_code);
             assert_eq!(op_code.condition, Condition::AL);
-            assert_eq!(op_code.instruction, ArmModeInstruction::DataProcessing3);
+            assert_eq!(op_code.instruction, ArmModeInstruction::DataProcessing);
 
             cpu.execute(op_code);
             let rotated = rx.rotate_right(is * 2);

--- a/emu/src/data_processing.rs
+++ b/emu/src/data_processing.rs
@@ -251,21 +251,29 @@ impl Arm7tdmi {
             ArmModeAluInstruction::Tst => {
                 if s {
                     self.tst(rn, op2)
+                } else {
+                    unimplemented!("Implement PSR transfer")
                 }
             }
             ArmModeAluInstruction::Teq => {
                 if s {
                     self.teq(rn, op2)
+                } else {
+                    unimplemented!("Implement PSR transfer")
                 }
             }
             ArmModeAluInstruction::Cmp => {
                 if s {
                     self.cmp(rn, op2)
+                } else {
+                    unimplemented!("Implement PSR transfer")
                 }
             }
             ArmModeAluInstruction::Cmn => {
                 if s {
                     self.cmn(rn, op2)
+                } else {
+                    unimplemented!("Implement PSR transfer")
                 }
             }
             ArmModeAluInstruction::Orr => self.orr(rd.try_into().unwrap(), rn, op2, s),
@@ -495,23 +503,20 @@ mod tests {
 
     #[test]
     fn check_teq() {
-        // This case cover S=0 then it will skip the execution of TEQ.
-        {
-            let op_code = 0b1110_0001_0010_1001_0011_0000_0000_0000;
-            let mut cpu = Arm7tdmi::default();
-            let op_code = cpu.decode(op_code);
-            assert_eq!(op_code.instruction, ArmModeInstruction::DataProcessing);
-            let rn = 9_usize;
-            cpu.registers.set_register_at(rn, 100);
-            cpu.cpsr.set_sign_flag(true); // set for later verify.
-            cpu.execute(op_code);
-            assert!(cpu.cpsr.sign_flag());
-            assert!(!cpu.cpsr.zero_flag());
-        }
+        let op_code = 0b1110_0001_0011_1001_0011_0000_0000_0000;
+        let mut cpu = Arm7tdmi::default();
+        let op_code = cpu.decode(op_code);
+        assert_eq!(op_code.instruction, ArmModeInstruction::DataProcessing);
+        let rn = 9_usize;
+        cpu.registers.set_register_at(rn, 100);
+        cpu.cpsr.set_sign_flag(true); // set for later verify.
+        cpu.execute(op_code);
+        assert!(!cpu.cpsr.sign_flag());
+        assert!(!cpu.cpsr.zero_flag());
     }
 
     #[test]
-    fn check_cmp_s1() {
+    fn check_cmp() {
         let op_code: u32 = 0b1110_0001_0011_1010_0011_0000_0000_0000;
         let mut cpu = Arm7tdmi::default();
         let op_code = cpu.decode(op_code);
@@ -521,20 +526,6 @@ mod tests {
         cpu.execute(op_code);
         assert!(!cpu.cpsr.sign_flag());
         assert!(cpu.cpsr.zero_flag());
-    }
-
-    #[test]
-    fn check_cmp_s0() {
-        let op_code: u32 = 0b1110_0001_0010_1010_0011_0000_0000_0000;
-        let mut cpu = Arm7tdmi::default();
-        let op_code = cpu.decode(op_code);
-        assert_eq!(op_code.instruction, ArmModeInstruction::DataProcessing);
-        let rn = 9_usize;
-        cpu.registers.set_register_at(rn, 1);
-        cpu.cpsr.set_sign_flag(true); // set for later verify.
-        cpu.execute(op_code);
-        assert!(cpu.cpsr.sign_flag());
-        assert!(!cpu.cpsr.zero_flag());
     }
 
     #[test]
@@ -681,22 +672,11 @@ mod tests {
 
     #[test]
     fn check_tst() {
-        // Covers S = 0
-        let op_code = 0b1110_00_1_1000_0_0000_0001_0000_10101010;
         let mut cpu = Arm7tdmi::default();
-        let op_code = cpu.decode(op_code);
-
-        cpu.registers.set_register_at(0, 0b11111111);
-
-        cpu.execute(op_code);
-
-        assert!(!cpu.cpsr.zero_flag());
-        assert!(!cpu.cpsr.sign_flag());
-
-        cpu.cpsr.set_sign_flag(true);
-        // Covers S = 1
         let op_code = 0b1110_00_1_1000_1_0000_0001_0000_00000000;
         let op_code = cpu.decode(op_code);
+
+        cpu.cpsr.set_sign_flag(true);
 
         cpu.execute(op_code);
 

--- a/emu/src/instruction.rs
+++ b/emu/src/instruction.rs
@@ -2,58 +2,79 @@ use std::fmt::{Display, Formatter};
 
 use logger::log;
 
+use crate::bitwise::Bits;
+
 #[derive(Debug, PartialEq, Eq)]
 pub enum ArmModeInstruction {
-    DataProcessing1 = 0b0000_0000_0000_0000_0000_0000_0000_0000,
-    DataProcessing2 = 0b0000_0000_0000_0000_0000_0000_0001_0000,
-    DataProcessing3 = 0b0000_0010_0000_0000_0000_0000_0000_0000,
-    Branch = 0b0000_1010_0000_0000_0000_0000_0000_0000,
-    BranchLink = 0b0000_1011_0000_0000_0000_0000_0000_0000,
-    TransImm9 = 0b0000_0100_0000_0000_0000_0000_0000_0000,
-    BlockDataTransfer = 0b0000_1000_0000_0000_0000_0000_0000_0000,
-    Unknown,
+    DataProcessing,
+    Multiply,
+    MultiplyLong,
+    SingleDataSwap,
+    BranchAndExchange,
+    HalfwordDataTransferRegisterOffset,
+    HalfwordDataTransferImmediateOffset,
+    SingleDataTransfer,
+    Undefined,
+    BlockDataTransfer,
+    Branch,
+    CoprocessorDataTransfer,
+    CoprocessorDataOperation,
+    CoprocessorRegisterTrasfer,
+    SoftwareInterrupt,
 }
 
 impl From<u32> for ArmModeInstruction {
     fn from(op_code: u32) -> Self {
         use ArmModeInstruction::*;
 
-        if Self::check(DataProcessing1, op_code) {
-            DataProcessing1
-        } else if Self::check(DataProcessing2, op_code) {
-            DataProcessing2
-        } else if Self::check(DataProcessing3, op_code) {
-            DataProcessing3
-        } else if Self::check(Branch, op_code) {
-            Branch
-        } else if Self::check(BranchLink, op_code) {
-            BranchLink
-        } else if Self::check(TransImm9, op_code) {
-            TransImm9
-        } else if Self::check(BlockDataTransfer, op_code) {
+        // NOTE: The order is based on how many bits are already know at decoding time.
+        // It can happen `op_code` coalesced into one/two or more than two possible solution, that's because
+        // we tried to order with this priority.
+        if op_code.get_bits(4..=27) == 0b0001_0010_1111_1111_1111_0001 {
+            BranchAndExchange
+        } else if op_code.get_bits(23..=27) == 0b00010
+            && op_code.get_bits(20..=21) == 0b00
+            && op_code.get_bits(4..=11) == 0b0000_1001
+        {
+            SingleDataSwap
+        } else if op_code.get_bits(22..=27) == 0b000000 && op_code.get_bits(4..=7) == 0b1001 {
+            Multiply
+        } else if op_code.get_bits(23..=27) == 0b00001 && op_code.get_bits(4..=7) == 0b1001 {
+            MultiplyLong
+        } else if op_code.get_bits(25..=27) == 0b000
+            && !op_code.get_bit(22)
+            && op_code.get_bits(7..=11) == 0b00001
+            && op_code.get_bit(4)
+        {
+            HalfwordDataTransferRegisterOffset
+        } else if op_code.get_bits(25..=27) == 0b000
+            && op_code.get_bit(22)
+            && op_code.get_bit(7)
+            && op_code.get_bit(4)
+        {
+            HalfwordDataTransferImmediateOffset
+        } else if op_code.get_bits(25..=27) == 0b011 && op_code.get_bit(4) {
+            log("undefined instruction decode...");
+            Undefined
+        } else if op_code.get_bits(24..=27) == 0b1111 {
+            SoftwareInterrupt
+        } else if op_code.get_bits(24..=27) == 0b1110 && op_code.get_bit(4) {
+            CoprocessorRegisterTrasfer
+        } else if op_code.get_bits(24..=27) == 0b1110 && !op_code.get_bit(4) {
+            CoprocessorDataOperation
+        } else if op_code.get_bits(25..=27) == 0b110 {
+            CoprocessorDataTransfer
+        } else if op_code.get_bits(25..=27) == 0b100 {
             BlockDataTransfer
+        } else if op_code.get_bits(25..=27) == 0b101 {
+            Branch
+        } else if op_code.get_bits(26..=27) == 0b01 {
+            SingleDataTransfer
+        } else if op_code.get_bits(26..=27) == 0b00 {
+            DataProcessing
         } else {
-            log(format!("{op_code:b}"));
-            Unknown
-        }
-    }
-}
-
-impl ArmModeInstruction {
-    const fn check(instruction_type: Self, op_code: u32) -> bool {
-        (Self::get_mask(&instruction_type) & op_code) == instruction_type as u32
-    }
-
-    const fn get_mask(instruction_type: &Self) -> u32 {
-        use ArmModeInstruction::*;
-
-        match instruction_type {
-            Branch | BranchLink => 0b0000_1111_0000_0000_0000_0000_0000_0000,
-            DataProcessing1 | DataProcessing2 => 0b0000_1110_0000_0000_0000_0000_0001_0000,
-            DataProcessing3 => 0b0000_1110_0000_0000_0000_0000_0000_0000,
-            TransImm9 => 0b0000_1110_0000_0000_0000_0000_0000_0000,
-            BlockDataTransfer => 0b0000_1110_0000_0000_0000_0000_0000_0000,
-            Unknown => 0b1111_1111_1111_1111_1111_1111_1111_1111,
+            log("not identified instruction");
+            unimplemented!()
         }
     }
 }
@@ -61,5 +82,36 @@ impl ArmModeInstruction {
 impl Display for ArmModeInstruction {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{instruction::ArmModeInstruction, opcode::ArmModeOpcode};
+
+    #[test]
+    fn decode_half_word_data_transfer_immediate_offset() {
+        let output: ArmModeInstruction = 0b1110_0001_1100_0001_0000_0000_1011_0000.into();
+        assert_eq!(
+            output,
+            ArmModeInstruction::HalfwordDataTransferImmediateOffset
+        );
+    }
+
+    // FIXME: Not sure about this, just because `BranchAndExchange` if is first.
+    #[test]
+    fn decode_branch_and_exchange() {
+        let output: ArmModeOpcode = 0b1110_0001_0010_1111_1111_1111_0001_0001
+            .try_into()
+            .unwrap();
+        assert_eq!(output.instruction, ArmModeInstruction::BranchAndExchange);
+    }
+
+    #[test]
+    fn decode_branch_link() {
+        let output: ArmModeOpcode = 0b1110_1011_0000_0000_0000_0000_0111_1111
+            .try_into()
+            .unwrap();
+        assert_eq!(output.instruction, ArmModeInstruction::Branch);
     }
 }

--- a/emu/src/opcode.rs
+++ b/emu/src/opcode.rs
@@ -47,7 +47,9 @@ impl Display for ArmModeOpcode {
             ArmModeInstruction::SingleDataSwap => "FMT: |_Cond__|",
             ArmModeInstruction::BranchAndExchange => "FMT: |_Cond__|",
             ArmModeInstruction::HalfwordDataTransferRegisterOffset => "FMT: |_Cond__|",
-            ArmModeInstruction::HalfwordDataTransferImmediateOffset => "FMT: |_Cond__|",
+            ArmModeInstruction::HalfwordDataTransferImmediateOffset => {
+                "FMT: |_Cond__|0_0_0|P|U|1|W|L|__Rn___|__Rd___|_Offset|1|S|H|1|_Offset|"
+            }
             ArmModeInstruction::SingleDataTransfer => {
                 "FMT: |_Cond__|0_1|I|P|U|B|W|L|__Rn___|__Rd___|________Offset_________|"
             }

--- a/emu/src/opcode.rs
+++ b/emu/src/opcode.rs
@@ -38,97 +38,30 @@ impl Display for ArmModeOpcode {
         let bytes_pos1 = "POS: |..3 ..................2 ..................1 ..................0|\n";
         let bytes_pos2 = "     |1_0_9_8_7_6_5_4_3_2_1_0_9_8_7_6_5_4_3_2_1_0_9_8_7_6_5_4_3_2_1_0|\n";
 
-        let op_code_format: &str = match self.instruction {
-            ArmModeInstruction::DataProcessing1 => {
-                "FMT: |_Cond__|0_0_0|___Op__|S|__Rn___|__Rd___|__Shift__|Typ|0|__Rm___|\n"
+        let op_code_format: &str = match &self.instruction {
+            ArmModeInstruction::DataProcessing => {
+                "FMT: |_Cond__|0_0|I|_code__|S|__Rn___|__Rd___|_______operand2________|"
             }
-            ArmModeInstruction::DataProcessing2 => {
-                "FMT: |_Cond__|0_0_0|___Op__|S|__Rn___|__Rd___|__Rs___|0|Typ|1|__Rm___|\n"
+            ArmModeInstruction::Multiply => "FMT: |_Cond__|",
+            ArmModeInstruction::MultiplyLong => "FMT: |_Cond__|",
+            ArmModeInstruction::SingleDataSwap => "FMT: |_Cond__|",
+            ArmModeInstruction::BranchAndExchange => "FMT: |_Cond__|",
+            ArmModeInstruction::HalfwordDataTransferRegisterOffset => "FMT: |_Cond__|",
+            ArmModeInstruction::HalfwordDataTransferImmediateOffset => "FMT: |_Cond__|",
+            ArmModeInstruction::SingleDataTransfer => {
+                "FMT: |_Cond__|0_1|I|P|U|B|W|L|__Rn___|__Rd___|________Offset_________|"
             }
-            ArmModeInstruction::DataProcessing3 => {
-                "FMT: |_Cond__|0_0_1|___Op__|S|__Rn___|__Rd___|_Shift_|___Immediate___|\n"
-            }
-            ArmModeInstruction::TransImm9 => {
-                "FMT: |_Cond__|0_1_0|P|U|B|W|L|__Rn___|__Rd___|_________Offset________|\n"
-            }
-            ArmModeInstruction::Branch | ArmModeInstruction::BranchLink => {
-                "FMT: |_Cond__|1_0_1|L|___________________Offset______________________|\n"
-            }
+            ArmModeInstruction::Undefined => "FMT: |_Cond__|",
             ArmModeInstruction::BlockDataTransfer => {
-                "FMT: |_Cond__|1_0_0|P|U|S|W|L|__Rn___|__________Register_List________|\n"
+                "FMT: |_Cond__|1_0_0|P|U|S|W|L|__Rn___|_____________Reg_List__________|"
             }
-            ArmModeInstruction::Unknown => "",
-        };
-
-        // let cond = self.get_bits(28..=31);
-        // Nice way to disable this block of code
-        #[cfg(feature = "")]
-        let op_code_value: String = match self.instruction {
-            ArmModeInstruction::DataProcessing1 => {
-                let op = self.get_bits(21..=24);
-                let s = self.get_bit(20) as u8;
-                let rn = self.get_bits(16..=19);
-                let rd = self.get_bits(12..=15);
-                let shift_amount = self.get_bits(7..=11);
-                let shift_type = self.get_bits(5..=6);
-                let rm = self.get_bits(0..=3);
-
-                format!("HEX: |{cond:07X}|0_0_0|{op:07X}|{s:01X}|{rn:07X}|{rd:07X}|{shift_amount:09X}|{shift_type:03X}|0|{rm:07X}|\n\
-                         DEC: |{cond:07}|0_0_0|{op:07}|{s:01}|{rn:07}|{rd:07}|{shift_amount:09}|{shift_type:03}|0|{rm:07}|\n\
-                         BIN: |{cond:07b}|0_0_0|{op:07b}|{s:01b}|{rn:07b}|{rd:07b}|{shift_amount:09b}|{shift_type:03b}|0|{rm:07b}|\n")
+            ArmModeInstruction::Branch => {
+                "FMT: |_Cond__|1_0_1|L|______________________Offset___________________|"
             }
-            ArmModeInstruction::DataProcessing2 => {
-                let op = self.get_bits(21..=24);
-                let s = self.get_bit(20) as u8;
-                let rn = self.get_bits(16..=19);
-                let rd = self.get_bits(12..=15);
-                let rs = self.get_bits(8..=11);
-                let shift_type = self.get_bits(5..=6);
-                let rm = self.get_bits(0..=3);
-
-                format!("HEX: |{cond:07X}|0_0_0|{op:07X}|{s:01X}|{rn:07X}|{rd:07X}|{rs:07X}|0|{shift_type:03X}|1|{rm:07X}|\n\
-                         DEC: |{cond:07}|0_0_0|{op:07}|{s:01}|{rn:07}|{rd:07}|{rs:07}|0|{shift_type:03}|1|{rm:07}|\n\
-                         BIN: |{cond:07b}|0_0_0|{op:07b}|{s:01b}|{rn:07b}|{rd:07b}|{rs:07b}|0|{shift_type:03b}|1|{rm:07b}|\n")
-            }
-            ArmModeInstruction::DataProcessing3 => {
-                let op = self.get_bits(21..=24);
-                let s = self.get_bit(20) as u8;
-                let rn = self.get_bits(16..=19);
-                let rd = self.get_bits(12..=15);
-                let shift_amount = self.get_bits(8..=11);
-                let immediate = self.get_bits(0..=7);
-
-                format!("HEX: |{cond:07X}|0_0_1|{op:07X}|{s:01X}|{rn:07X}|{rd:07X}|{shift_amount:07X}|{immediate:015X}|\n\
-                         DEC: |{cond:07}|0_0_1|{op:07}|{s:01}|{rn:07}|{rd:07}|{shift_amount:07}|{immediate:015}|\n\
-                         BIN: |{cond:07b}|0_0_1|{op:07b}|{s:01b}|{rn:07b}|{rd:07b}|{shift_amount:07b}|{immediate:015b}|\n")
-            }
-            ArmModeInstruction::TransImm9 => {
-                let p = self.get_bit(24) as u8;
-                let u = self.get_bit(23) as u8;
-                let b = self.get_bit(22) as u8;
-                let w = self.get_bit(21) as u8;
-                let l = self.get_bit(20) as u8;
-                let rn = self.get_bits(16..=19);
-                let rd = self.get_bits(12..=15);
-                let offset = self.get_bits(0..=11);
-
-                format!("HEX: |{cond:07X}|0_1_0|{p:01X}|{u:01X}|{b:01X}|{w:01X}|{l:01X}|{rn:07X}|{rd:07X}|{offset:023X}|\n\
-                         DEC: |{cond:07}|0_1_0|{p:01}|{u:01}|{b:01}|{w:01}|{l:01}|{rn:07}|{rd:07}|{offset:023}|\n\
-                         BIN: |{cond:07b}|0_1_0|{p:01b}|{u:01b}|{b:01b}|{w:01b}|{l:01b}|{rn:07b}|{rd:07b}|{offset:023b}|\n")
-            }
-            ArmModeInstruction::Branch | ArmModeInstruction::BranchLink => {
-                let l = self.get_bit(24) as u8;
-                let offset = self.get_bits(0..=23);
-                format!(
-                    "HEX: |{cond:07X}|1_0_1|{l:01X}|{offset:047X}|\n\
-                     DEC: |{cond:07}|1_0_1|{l:01}|{offset:047}|\n\
-                     BIN: |{cond:07b}|1_0_1|{l:01b}|{offset:047b}|\n"
-                )
-            }
-            ArmModeInstruction::BlockDataTransfer => {
-                format!("just skip this for now")
-            }
-            ArmModeInstruction::Unknown => String::new(),
+            ArmModeInstruction::CoprocessorDataTransfer => "FMT: |_Cond__|",
+            ArmModeInstruction::CoprocessorDataOperation => "FMT: |_Cond__|",
+            ArmModeInstruction::CoprocessorRegisterTrasfer => "FMT: |_Cond__|",
+            ArmModeInstruction::SoftwareInterrupt => "FMT: |_Cond__|",
         };
 
         let mut raw_bits = String::new();
@@ -139,7 +72,7 @@ impl Display for ArmModeOpcode {
         raw_bits.pop();
         let raw_bits = format!("RAW: |{}|\n", raw_bits);
 
-        write!(
+        writeln!(
             f,
             "{instruction}{bytes_pos1}{bytes_pos2}{raw_bits}{op_code_format}"
         )

--- a/emu/src/single_data_transfer.rs
+++ b/emu/src/single_data_transfer.rs
@@ -142,7 +142,10 @@ mod tests {
         let mut cpu = Arm7tdmi::default();
 
         let op_code_type = cpu.decode(op_code);
-        assert_eq!(op_code_type.instruction, ArmModeInstruction::TransImm9);
+        assert_eq!(
+            op_code_type.instruction,
+            ArmModeInstruction::SingleDataTransfer
+        );
 
         let rd: u8 = ((op_code & 0b0000_0000_0000_0000_1111_0000_0000_0000) >> 12)
             .try_into()
@@ -168,7 +171,10 @@ mod tests {
         let mut cpu = Arm7tdmi::default();
 
         let op_code_type = cpu.decode(op_code);
-        assert_eq!(op_code_type.instruction, ArmModeInstruction::TransImm9);
+        assert_eq!(
+            op_code_type.instruction,
+            ArmModeInstruction::SingleDataTransfer
+        );
 
         let rd: u8 = ((op_code & 0b0000_0000_0000_0000_1111_0000_0000_0000) >> 12)
             .try_into()
@@ -194,7 +200,10 @@ mod tests {
         let mut cpu = Arm7tdmi::default();
 
         let op_code_type = cpu.decode(op_code);
-        assert_eq!(op_code_type.instruction, ArmModeInstruction::TransImm9);
+        assert_eq!(
+            op_code_type.instruction,
+            ArmModeInstruction::SingleDataTransfer
+        );
 
         let rd: u8 = ((op_code & 0b0000_0000_0000_0000_1111_0000_0000_0000) >> 12)
             .try_into()
@@ -222,7 +231,10 @@ mod tests {
         let op_code: u32 = 0b1110_0101_1000_0001_0001_0000_0000_0000;
         let mut cpu = Arm7tdmi::default();
         let op_code_type = cpu.decode(op_code);
-        assert_eq!(op_code_type.instruction, ArmModeInstruction::TransImm9);
+        assert_eq!(
+            op_code_type.instruction,
+            ArmModeInstruction::SingleDataTransfer
+        );
 
         let rd: u8 = ((op_code & 0b0000_0000_0000_0000_1111_0000_0000_0000) >> 12)
             .try_into()

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ fn main() {
             std::process::exit(1)
         },
         |name| {
-            log("loading {name}");
+            log(format!("loading {name}"));
             name.clone()
         },
     );


### PR DESCRIPTION
Aligned all instruction with the document of proper CPU. Many of those
are not implemented, neither displayed well in formatted log, but now we
have all istruction decode well (I hope :')).
Now is more easy to understand which bits should be true/false, using
mask were not so easy to understand from the log.
The decode function is ordered on how many bit are already know as
invariant.

![Screenshot 2022-11-12 at 16 33 35](https://user-images.githubusercontent.com/41150432/201483979-a5b168d5-d237-4078-9dd7-eb424dd73f6f.png)
