### PR TITLE
Add render in BG_MODE_4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ target/
 
 # Support for Project snippet scope
 .vscode/*.code-snippets
+.vscode/
 
 # Ignore code-workspaces
 *.code-workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,6 +683,7 @@ name = "emu"
 version = "0.1.0"
 dependencies = [
  "logger",
+ "macros",
  "pretty_assertions",
  "rand",
 ]
@@ -1191,6 +1192,10 @@ dependencies = [
  "chrono",
  "once_cell",
 ]
+
+[[package]]
+name = "macros"
+version = "0.1.0"
 
 [[package]]
 name = "malloc_buf"
@@ -2030,6 +2035,7 @@ dependencies = [
  "emu",
  "image",
  "logger",
+ "macros",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "clementine"
 version = "0.1.0"
 
 [workspace]
-members = ["emu", "ui", "logger"]
+members = ["emu", "ui", "logger", "macros"]
 
 [workspace.package]
 readme = "./README.md"
@@ -21,6 +21,7 @@ emu = { path = "./emu" }
 ui = { path  = "./ui" }
 logger = { path = "./logger" }
 
+
 [dev-dependencies]
 pretty_assertions = "1.3.0"
 rand = "0.8.5"
@@ -30,5 +31,6 @@ debug = [
     "ui/debug"
 ]
 
-test_bitmap_3 = ["ui/test_bitmap_3"]
-test_bitmap_5 = ["ui/test_bitmap_5"]
+test_mode_3 = ["ui/test_mode_3"]
+test_mode_4 = ["ui/test_mode_4"]
+test_mode_5 = ["ui/test_mode_5"]

--- a/emu/Cargo.toml
+++ b/emu/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 
 [dependencies]
 logger = { path = "../logger" }
+macros = { path = "../macros"}
 rand = { version = "0.8.5", optional = true}
 
 [dev-dependencies]
@@ -16,4 +17,5 @@ rand = "0.8.5"
 [features]
 debug = ["rand"]
 mode_5 = ["debug"]
+mode_4 = ["debug"]
 mode_3 = ["debug"]

--- a/emu/src/gba.rs
+++ b/emu/src/gba.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, Mutex};
 use crate::{
     arm7tdmi::Arm7tdmi,
     cartridge_header::CartridgeHeader,
+    cpu::Cpu,
     memory::internal_memory::InternalMemory,
     render::{gba_lcd::GbaLcd, ppu::PixelProcessUnit},
 };
@@ -33,5 +34,10 @@ impl Gba {
             lcd,
             memory,
         }
+    }
+
+    pub fn step(&mut self) {
+        self.cpu.step();
+        self.ppu.render();
     }
 }

--- a/justfile
+++ b/justfile
@@ -18,11 +18,15 @@ set positional-arguments
 
 # run clemente in DEBUG mode
 @test_mode_3 *args='':
-    @cargo run --features test_bitmap_3 -- $1
+    @cargo run --features test_mode_3 -- $1
+
+# run clemente in DEBUG mode
+@test_mode_4 *args='':
+    @cargo run --features test_mode_4 -- $1
 
 # run clemente in DEBUG mode
 @test_mode_5 *args='':
-    @cargo run --features test_bitmap_5 -- $1
+    @cargo run --features test_mode_5 -- $1
 
 # run clippy with heavy config
 lint:

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "macros"
+version = "0.1.0"
+edition.workspace = true
+repository.workspace = true
+license.workspace = true

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod utility_macros;

--- a/macros/src/utility_macros.rs
+++ b/macros/src/utility_macros.rs
@@ -1,0 +1,10 @@
+#[macro_export]
+macro_rules! acquire_lock {
+    ($mutex:expr, $lock:ident => $exec:block ) => {
+        match $mutex.lock() {
+            #[allow(unused_mut)]
+            Ok(mut $lock) => $exec,
+            _ => Default::default(),
+        }
+    };
+}

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -7,6 +7,8 @@ license.workspace = true
 
 [dependencies]
 logger = { path = "../logger" }
+macros = { path = "../macros"}
+
 eframe = { version = "0.19.0", git = "https://github.com/emilk/egui", default-features = false, features = ["glow"] }
 egui = { version = "0.19.0", git = "https://github.com/emilk/egui", default-features = false }
 egui_extras = { version = "0.19.0", git = "https://github.com/emilk/egui", features = ["image"] }
@@ -15,14 +17,21 @@ image = { version = "0.24", features = ["png"], optional = true}
 
 [features]
 debug = ["emu/debug"]
-test_bitmap_3 = [ 
+test_mode_3 = [ 
     "debug", 
     "emu/mode_3" , 
     "egui_extras/image", 
     "image"
 ]
 
-test_bitmap_5 = [ 
+test_mode_4 = [ 
+    "debug", 
+    "emu/mode_4" , 
+    "egui_extras/image", 
+    "image"
+]
+
+test_mode_5 = [ 
     "debug", 
     "emu/mode_5" , 
     "egui_extras/image", 

--- a/ui/src/cpu_inspector.rs
+++ b/ui/src/cpu_inspector.rs
@@ -1,10 +1,14 @@
 use emu::{cpu::Cpu, gba::Gba};
+use macros::acquire_lock;
 
 use crate::ui_traits::{UiTool, View};
 
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
 use std::thread;
+use std::time::Duration;
+
+const FPS: u64 = 24;
 
 pub struct CpuInspector {
     gba: Arc<Mutex<Gba>>,
@@ -67,7 +71,8 @@ impl View for CpuInspector {
 
                 self.thread_handle = Some(thread::spawn(move || {
                     while play_clone.load(std::sync::atomic::Ordering::Relaxed) {
-                        gba_clone.lock().unwrap().cpu.step();
+                        thread::sleep(Duration::from_millis(1000 / FPS));
+                        acquire_lock!(gba_clone, gba => {gba.step()});
                     }
                 }));
             }

--- a/ui/src/gba_display.rs
+++ b/ui/src/gba_display.rs
@@ -1,4 +1,5 @@
 use egui::{self, Color32, ColorImage, Vec2};
+use macros::acquire_lock;
 
 use std::sync::{Arc, Mutex};
 
@@ -14,7 +15,6 @@ use crate::{
 
 pub struct GbaDisplay {
     image: egui::ColorImage,
-    texture: Option<egui::TextureHandle>,
     gba: Arc<Mutex<Gba>>,
     scale: f32,
 }
@@ -24,25 +24,29 @@ impl GbaDisplay {
         #[allow(unused_mut)]
         let mut res = Self {
             image: ColorImage::new([LCD_WIDTH, LCD_HEIGHT], Color32::BLACK),
-            texture: None,
             gba,
             scale: 1.0,
         };
 
-        #[cfg(feature = "test_bitmap_3")]
+        #[cfg(feature = "test_mode_3")]
         {
             res.load_test_mode_3();
         }
 
-        #[cfg(feature = "test_bitmap_5")]
+        #[cfg(feature = "test_mode_4")]
         {
-            res.load_test_mode_5();
+            res.test_mode_4();
+        }
+
+        #[cfg(feature = "test_mode_5")]
+        {
+            res.test_mode_5();
         }
 
         res
     }
 
-    #[cfg(feature = "test_bitmap_3")]
+    #[cfg(feature = "test_mode_3")]
     pub fn load_test_mode_3(&mut self) {
         let image_data = include_bytes!("../../img/clementine_logo_test_bitmap.png");
         let color_image: ColorImage =
@@ -64,8 +68,8 @@ impl GbaDisplay {
         }
     }
 
-    #[cfg(feature = "test_bitmap_5")]
-    pub fn load_test_mode_5(&mut self) {
+    #[cfg(feature = "test_mode_5")]
+    pub fn test_mode_5(&mut self) {
         let image_data = include_bytes!("../../img/clementine_logo_160px.png");
         let color_image: ColorImage =
             egui_extras::image::load_image_bytes(image_data).expect("Failed to load image");
@@ -85,6 +89,13 @@ impl GbaDisplay {
             gba.ppu.load_gbc_bitmap(bitmap_data, size[0], size[1]);
         }
     }
+
+    #[cfg(feature = "test_mode_4")]
+    pub fn test_mode_4(&self) {
+        if let Ok(mut gba) = self.gba.lock() {
+            gba.ppu.load_default_palette();
+        }
+    }
 }
 
 impl View for GbaDisplay {
@@ -101,30 +112,26 @@ impl View for GbaDisplay {
             }
         });
 
-        let gba = self.gba.lock().unwrap();
-
-        gba.ppu.render();
-        for row in 0..LCD_HEIGHT {
-            for col in 0..LCD_WIDTH {
-                let gba_lcd = gba.lcd.lock().unwrap();
-                self.image[(col, row)] = GbaColor(gba_lcd[(col, row)]).into();
+        acquire_lock!(self.gba, gba => {
+            for row in 0..LCD_HEIGHT {
+                for col in 0..LCD_WIDTH {
+                    self.image[(col, row)] =
+                        GbaColor(gba.lcd.lock().unwrap()[(col, row)]).into();
+                }
             }
-        }
-
-        let texture: &egui::TextureHandle = self.texture.get_or_insert_with(|| {
-            // Load the texture only once.
-            ui.ctx().load_texture(
-                "gba_display",
-                self.image.clone(),
-                egui::TextureFilter::Linear,
-            )
         });
 
-        let size = Vec2::new(
-            texture.size_vec2().x * self.scale,
-            texture.size_vec2().y * self.scale,
+        let screen = ui.ctx().load_texture(
+            "gba_display",
+            self.image.clone(),
+            egui::TextureFilter::Linear,
         );
-        ui.image(texture, size);
+
+        let size = Vec2::new(
+            screen.size_vec2().x * self.scale,
+            screen.size_vec2().y * self.scale,
+        );
+        ui.image(&screen, size);
     }
 }
 


### PR DESCRIPTION
Documented here: [BG_MODE_4](https://rust-console.github.io/gbatek-gbaonly/#bg-mode-4---240x160-pixels-256-colors-out-of-32768-colors)

In this PR I also added a macro to simplify lock syntax:

`acquire_lock!(lock_var, acquired => { you can use acquired here } );`

It was usefull because sometime we have to acquire a lock only in the needed scopes. In this way it is more cleaner to use a mutex more times in the same flow. 

For example assume you have two function `fn_1()`, `fn_2()`

```
fn_1() {
  // it needs a lock
  let acquired_var = self.lock_var.lock().unwrap();
  acquired_var.do_something();

 fn_2();
}
```

```
fn_2() {
  // it needs a lock
  let acquired_var = self.lock_var.lock().unwrap();
  acquired_var.do_other_stuff();
}
```
if you call `fn_1()` a deadlock occurs.

with this macro you can do this without problems:
```
fn_1() {
  // it needs a lock
  acquire_lock!(self.lock_var, var => { var.do_something(); });
 fn_2();
}
```

With `just test_mode_4 path/rom.gba` you can check the correct behavior with the help of `PaletteVisualizer`.
