### PR TITLE
`spsr` and register bank

### DIFF
--- a/emu/src/arm/arm7tdmi.rs
+++ b/emu/src/arm/arm7tdmi.rs
@@ -3,9 +3,10 @@ use std::sync::{Arc, Mutex};
 
 use logger::log;
 
-use crate::arm::cpsr::Cpsr;
+use crate::arm::cpu_modes::Mode;
 use crate::arm::instruction::ArmModeInstruction;
 use crate::arm::opcode::ArmModeOpcode;
+use crate::arm::psr::Psr;
 use crate::bitwise::Bits;
 use crate::cpu::Cpu;
 use crate::memory::internal_memory::InternalMemory;
@@ -43,13 +44,23 @@ impl Registers {
     }
 }
 
-#[derive(Default)]
 pub struct Arm7tdmi {
     pub(crate) rom: Arc<Mutex<Vec<u8>>>,
     pub(crate) memory: Arc<Mutex<InternalMemory>>,
 
-    pub cpsr: Cpsr,
+    pub cpsr: Psr,
     pub registers: Registers,
+}
+
+impl Default for Arm7tdmi {
+    fn default() -> Self {
+        Self {
+            rom: Arc::new(Mutex::new(Vec::default())),
+            memory: Arc::new(Mutex::new(InternalMemory::default())),
+            cpsr: Psr::from(Mode::User), // FIXME: Starting as User? Not sure
+            registers: Registers::default(),
+        }
+    }
 }
 
 const OPCODE_ARM_SIZE: usize = 4;
@@ -116,10 +127,9 @@ impl Cpu for Arm7tdmi {
 impl Arm7tdmi {
     pub fn new(rom: Arc<Mutex<Vec<u8>>>, memory: Arc<Mutex<InternalMemory>>) -> Self {
         Self {
-            rom,
-            registers: Registers::default(),
-            cpsr: Cpsr::default(),
             memory,
+            rom,
+            ..Default::default()
         }
     }
 

--- a/emu/src/arm/condition.rs
+++ b/emu/src/arm/condition.rs
@@ -79,37 +79,3 @@ impl From<u8> for Condition {
         }
     }
 }
-
-/// Control bits condition.
-pub enum ModeBits {
-    OldUser = 0x00,
-    OldFiq = 0x01,
-    OldIrq = 0x02,
-    OldSupervisor = 0x03,
-    User = 0x10,
-    Fiq = 0x11,
-    Irq = 0x12,
-    Supervisor = 0x13,
-    Abort = 0x17,
-    Undefined = 0x1B,
-    System = 0x1F,
-}
-
-impl From<u8> for ModeBits {
-    fn from(item: u8) -> Self {
-        match item {
-            0x00 => Self::OldUser,
-            0x01 => Self::OldFiq,
-            0x02 => Self::OldIrq,
-            0x03 => Self::OldSupervisor,
-            0x10 => Self::User,
-            0x11 => Self::Fiq,
-            0x12 => Self::Irq,
-            0x13 => Self::Supervisor,
-            0x17 => Self::Abort,
-            0x1B => Self::Undefined,
-            0x1F => Self::System,
-            _ => unreachable!(),
-        }
-    }
-}

--- a/emu/src/arm/cpu_modes.rs
+++ b/emu/src/arm/cpu_modes.rs
@@ -1,0 +1,33 @@
+#[derive(Debug, PartialEq, Eq)]
+pub enum Mode {
+    User = 0b10000,
+    Fiq = 0b10001,
+    Irq = 0b10010,
+    Supervisor = 0b10011,
+    Abort = 0b10111,
+    Undefined = 0b11011,
+    System = 0b11111,
+}
+
+impl From<Mode> for u32 {
+    fn from(m: Mode) -> Self {
+        m as Self
+    }
+}
+
+impl TryFrom<u32> for Mode {
+    type Error = String;
+
+    fn try_from(n: u32) -> Result<Self, Self::Error> {
+        match n {
+            0b10000 => Ok(Self::User),
+            0b10001 => Ok(Self::Fiq),
+            0b10010 => Ok(Self::Irq),
+            0b10011 => Ok(Self::Supervisor),
+            0b10111 => Ok(Self::Abort),
+            0b11011 => Ok(Self::Undefined),
+            0b11111 => Ok(Self::System),
+            _ => Err(String::from("Unexpected value for Mode")),
+        }
+    }
+}

--- a/emu/src/arm/mod.rs
+++ b/emu/src/arm/mod.rs
@@ -1,8 +1,9 @@
 mod alu_instruction;
 pub mod arm7tdmi;
 mod condition;
-mod cpsr;
+mod cpu_modes;
 mod data_processing;
 mod instruction;
 mod opcode;
+mod psr;
 mod single_data_transfer;

--- a/emu/src/arm/mod.rs
+++ b/emu/src/arm/mod.rs
@@ -6,4 +6,5 @@ mod data_processing;
 mod instruction;
 mod opcode;
 mod psr;
+mod register_bank;
 mod single_data_transfer;

--- a/emu/src/arm/psr.rs
+++ b/emu/src/arm/psr.rs
@@ -2,7 +2,7 @@ use crate::arm::{condition::Condition, cpu_modes::Mode, data_processing::Arithme
 use crate::bitwise::Bits;
 
 /// Program Status Register.
-#[derive(Default)]
+#[derive(Default, Clone, Copy)]
 pub struct Psr(u32);
 
 impl Psr {

--- a/emu/src/arm/register_bank.rs
+++ b/emu/src/arm/register_bank.rs
@@ -1,0 +1,25 @@
+use crate::arm::psr::Psr;
+
+#[derive(Default)]
+pub struct RegisterBank {
+    pub r8_fiq: u32,
+    pub r9_fiq: u32,
+    pub r10_fiq: u32,
+    pub r11_fiq: u32,
+    pub r12_fiq: u32,
+    pub r13_fiq: u32,
+    pub r14_fiq: u32,
+    pub r13_svc: u32,
+    pub r14_svc: u32,
+    pub r13_abt: u32,
+    pub r14_abt: u32,
+    pub r13_irq: u32,
+    pub r14_irq: u32,
+    pub r13_und: u32,
+    pub r14_und: u32,
+    pub spsr_fiq: Psr,
+    pub spsr_svc: Psr,
+    pub spsr_abt: Psr,
+    pub spsr_irq: Psr,
+    pub spsr_und: Psr,
+}


### PR DESCRIPTION
* Refactored `Cpsr` to `Psr` to use the same struct for both `cpsr` and `spsr`
* Added `RegisterBank` struct into `Armv7tdmi`. This struct stores the banked registers. Banked general purpose registers (R8-R14 for `fiq` and R13-R14 for `supervisor`, `abort`, `irq`, and `undefined`) are mapped to general purpose registers when in the given mode. For example: when in mode `fiq` if the CPU accesses R13, it's using the `r13_fiq`. For this reason, I've added `bank_registers` to save banked registers depending on the current mode and `restore_registers` to restore from the bank.

This work is preliminary to implementing `PSR` instructions and to fix all the instructions already implemented to take into account spsr registers in some specific cases


I'm not 100% sure the idea I came up with the `RegisterBank` is the best one, we can discuss it here and in any case, we'll see once we'll start using this machinery :D

Documentation: http://bear.ces.cwru.edu/eecs_382/ARM7-TDMI-manual-pt1.pdf pages from 3-4 to to 3-10 (except THUMB sections)