### PR TITLE
ROM in Memory

### DIFF
--- a/emu/src/arm/single_data_transfer.rs
+++ b/emu/src/arm/single_data_transfer.rs
@@ -85,9 +85,9 @@ impl Arm7tdmi {
         let load_store: SingleDataTransfer = op_code.into();
 
         let address = if up_down {
-            address.wrapping_sub(offset)
+            address.wrapping_sub(offset).try_into().unwrap()
         } else {
-            address.wrapping_add(offset)
+            address.wrapping_add(offset).try_into().unwrap()
         };
 
         let mut memory = self.memory.lock().unwrap();

--- a/emu/src/gba.rs
+++ b/emu/src/gba.rs
@@ -11,7 +11,6 @@ pub struct Gba {
     pub cpu: Arm7tdmi,
 
     pub cartridge_header: CartridgeHeader,
-    pub cartridge: Arc<Mutex<Vec<u8>>>,
 
     pub memory: Arc<Mutex<InternalMemory>>,
 
@@ -23,18 +22,14 @@ impl Gba {
     pub fn new(
         cartridge_header: CartridgeHeader,
         bios: [u8; 0x00004000],
-        cartridge: Arc<Mutex<Vec<u8>>>,
+        cartridge: Vec<u8>,
     ) -> Self {
         let lcd = Arc::new(Mutex::new(Box::new(GbaLcd::new())));
-        let memory = Arc::new(Mutex::new(InternalMemory::new(
-            bios,
-            Arc::clone(&cartridge),
-        )));
+        let memory = Arc::new(Mutex::new(InternalMemory::new(bios, cartridge)));
         let ppu = PixelProcessUnit::new(Arc::clone(&lcd), Arc::clone(&memory));
         let arm = Arm7tdmi::new(Arc::clone(&memory));
         Self {
             cpu: arm,
-            cartridge,
             cartridge_header,
             ppu,
             lcd,

--- a/emu/src/gba.rs
+++ b/emu/src/gba.rs
@@ -26,9 +26,12 @@ impl Gba {
         cartridge: Arc<Mutex<Vec<u8>>>,
     ) -> Self {
         let lcd = Arc::new(Mutex::new(Box::new(GbaLcd::new())));
-        let memory = Arc::new(Mutex::new(InternalMemory::new(bios)));
+        let memory = Arc::new(Mutex::new(InternalMemory::new(
+            bios,
+            Arc::clone(&cartridge),
+        )));
         let ppu = PixelProcessUnit::new(Arc::clone(&lcd), Arc::clone(&memory));
-        let arm = Arm7tdmi::new(Arc::clone(&cartridge), Arc::clone(&memory));
+        let arm = Arm7tdmi::new(Arc::clone(&memory));
         Self {
             cpu: arm,
             cartridge,

--- a/emu/src/memory/internal_memory.rs
+++ b/emu/src/memory/internal_memory.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
 
 use logger::log;
 
@@ -35,7 +34,13 @@ pub struct InternalMemory {
 
     /// From 0x08000000 to 0x0FFFFFFF.
     /// Basically here you can find different kind of rom loaded.
-    pub rom: Arc<Mutex<Vec<u8>>>,
+    // TODO: Not sure if we should split this into
+    // 08000000-09FFFFFF Game Pak ROM/FlashROM (max 32MB) - Wait State 0
+    // 0A000000-0BFFFFFF Game Pak ROM/FlashROM (max 32MB) - Wait State 1
+    // 0C000000-0DFFFFFF Game Pak ROM/FlashROM (max 32MB) - Wait State 2
+    // 0E000000-0E00FFFF Game Pak SRAM (max 64 KBytes) - 8bit Bus width
+    // 0E010000-0FFFFFFF Not used
+    pub rom: Vec<u8>,
 
     /// From 0x00004000 to 0x01FFFFFF.
     /// From 0x10000000 to 0xFFFFFFFF.
@@ -44,12 +49,12 @@ pub struct InternalMemory {
 
 impl Default for InternalMemory {
     fn default() -> Self {
-        Self::new([0_u8; 0x00004000], Arc::new(Mutex::new(vec![])))
+        Self::new([0_u8; 0x00004000], vec![])
     }
 }
 
 impl InternalMemory {
-    pub fn new(bios: [u8; 0x00004000], rom: Arc<Mutex<Vec<u8>>>) -> Self {
+    pub fn new(bios: [u8; 0x00004000], rom: Vec<u8>) -> Self {
         Self {
             bios_system_rom: bios.into(),
             working_ram: vec![0; 0x00040000],

--- a/emu/src/memory/internal_memory.rs
+++ b/emu/src/memory/internal_memory.rs
@@ -58,7 +58,7 @@ impl InternalMemory {
         }
     }
 
-    fn write_address_lcd_register(&mut self, address: u32, value: u8) {
+    fn write_address_lcd_register(&mut self, address: usize, value: u8) {
         match address {
             0x04000000 => self.lcd_registers.dispcnt.set_byte(0, value),
             0x04000001 => self.lcd_registers.dispcnt.set_byte(1, value),
@@ -147,7 +147,7 @@ impl InternalMemory {
         }
     }
 
-    fn read_address_lcd_register(&self, address: u32) -> u8 {
+    fn read_address_lcd_register(&self, address: usize) -> u8 {
         match address {
             0x04000000 => self.lcd_registers.dispcnt.read().get_byte(0),
             0x04000001 => self.lcd_registers.dispcnt.read().get_byte(1),
@@ -178,7 +178,7 @@ impl InternalMemory {
     }
 
     // There is no need to set the second byte because bits `8-15` are not used
-    fn write_address_timer_register(&mut self, address: u32, value: u8) {
+    fn write_address_timer_register(&mut self, address: usize, value: u8) {
         match address {
             0x04000100 => self.timer_registers.tm0cnt_l.set_byte(0, value),
             0x04000102 => self.timer_registers.tm0cnt_h.set_byte(0, value),
@@ -193,7 +193,7 @@ impl InternalMemory {
     }
 
     // There is no need to read the second byte because bits `8-15` are not used
-    fn read_address_timer_register(&self, address: u32) -> u8 {
+    fn read_address_timer_register(&self, address: usize) -> u8 {
         match address {
             0x04000100 => self.timer_registers.tm0cnt_l.read().get_byte(0),
             0x04000102 => self.timer_registers.tm0cnt_h.read().get_byte(0),
@@ -209,7 +209,7 @@ impl InternalMemory {
 }
 
 impl IoDevice for InternalMemory {
-    type Address = u32;
+    type Address = usize;
     type Value = u8;
 
     fn read_at(&self, address: Self::Address) -> Self::Value {
@@ -251,6 +251,17 @@ impl IoDevice for InternalMemory {
 
             _ => unimplemented!("Unimplemented memory region {address:x}."),
         }
+    }
+}
+
+impl InternalMemory {
+    pub fn read_word(&self, address: usize) -> u32 {
+        let part_0: u32 = self.read_at(address).try_into().unwrap();
+        let part_1: u32 = self.read_at(address + 1).try_into().unwrap();
+        let part_2: u32 = self.read_at(address + 2).try_into().unwrap();
+        let part_3: u32 = self.read_at(address + 3).try_into().unwrap();
+
+        part_3 << 24_u32 | part_2 << 16_u32 | part_1 << 8_u32 | part_0
     }
 }
 

--- a/emu/src/memory/internal_memory.rs
+++ b/emu/src/memory/internal_memory.rs
@@ -220,14 +220,15 @@ impl IoDevice for InternalMemory {
 
     fn read_at(&self, address: Self::Address) -> Self::Value {
         match address {
-            0x00000000..=0x00003FFF => self.bios_system_rom[(address) as usize],
-            0x02000000..=0x0203FFFF => self.working_ram[(address - 0x02000000) as usize],
-            0x03000000..=0x03007FFF => self.working_iram[(address - 0x03000000) as usize],
+            0x00000000..=0x00003FFF => self.bios_system_rom[address],
+            0x02000000..=0x0203FFFF => self.working_ram[address - 0x02000000],
+            0x03000000..=0x03007FFF => self.working_iram[address - 0x03000000],
             0x04000000..=0x04000055 => self.read_address_lcd_register(address),
             0x04000100..=0x0400010E => self.read_address_timer_register(address),
-            0x05000000..=0x050001FF => self.bg_palette_ram[(address - 0x05000000) as usize],
-            0x05000200..=0x050003FF => self.obj_palette_ram[(address - 0x05000200) as usize],
-            0x06000000..=0x06017FFF => self.video_ram[(address - 0x06000000) as usize],
+            0x05000000..=0x050001FF => self.bg_palette_ram[address - 0x05000000],
+            0x05000200..=0x050003FF => self.obj_palette_ram[address - 0x05000200],
+            0x06000000..=0x06017FFF => self.video_ram[address - 0x06000000],
+            0x08000000..=0x0FFFFFFF => self.rom[address - 0x08000000],
             0x03008000..=0x03FFFFFF | 0x00004000..=0x01FFFFFF | 0x10000000..=0xFFFFFFFF => {
                 log("read on unused memory");
                 self.unused_region
@@ -240,19 +241,20 @@ impl IoDevice for InternalMemory {
 
     fn write_at(&mut self, address: Self::Address, value: Self::Value) {
         match address {
-            0x00000000..=0x00003FFF => self.bios_system_rom[(address) as usize] = value,
-            0x02000000..=0x0203FFFF => self.working_ram[(address - 0x02000000) as usize] = value,
-            0x03000000..=0x03007FFF => self.working_iram[(address - 0x03000000) as usize] = value,
+            0x00000000..=0x00003FFF => self.bios_system_rom[address] = value,
+            0x02000000..=0x0203FFFF => self.working_ram[address - 0x02000000] = value,
+            0x03000000..=0x03007FFF => self.working_iram[address - 0x03000000] = value,
             0x04000000..=0x04000055 => self.write_address_lcd_register(address, value),
             0x04000100..=0x0400010E => self.write_address_timer_register(address, value),
-            0x05000000..=0x050001FF => self.bg_palette_ram[(address - 0x05000000) as usize] = value,
-            0x05000200..=0x050003FF => {
-                self.obj_palette_ram[(address - 0x05000200) as usize] = value
-            }
-            0x06000000..=0x06017FFF => self.video_ram[(address - 0x06000000) as usize] = value,
+            0x05000000..=0x050001FF => self.bg_palette_ram[address - 0x05000000] = value,
+            0x05000200..=0x050003FF => self.obj_palette_ram[address - 0x05000200] = value,
+            0x06000000..=0x06017FFF => self.video_ram[address - 0x06000000] = value,
             0x03008000..=0x03FFFFFF | 0x00004000..=0x01FFFFFF | 0x10000000..=0xFFFFFFFF => {
                 log("write on unused memory");
-                if self.unused_region.insert(address as usize, value).is_some() {}
+                if self.unused_region.insert(address, value).is_some() {}
+            }
+            0x08000000..=0x0FFFFFFF => {
+                self.rom[address - 0x08000000] = value;
             }
 
             _ => unimplemented!("Unimplemented memory region {address:x}."),

--- a/ui/src/dashboard.rs
+++ b/ui/src/dashboard.rs
@@ -44,7 +44,7 @@ impl UiTools {
         let arc_gba = Arc::new(Mutex::new(Gba::new(
             cartridge_header,
             bios[0..0x00004000].try_into().unwrap(),
-            Arc::new(Mutex::new(data)),
+            data,
         )));
 
         Self::from_tools(vec![


### PR DESCRIPTION
- Memory: Use for address `usize` type

This because in most of place is more convenient keep conversion outside the memory functions.


- CPU+Memory: Move rom data into memory

Now rom data is mapped into memory struct, that's because PC starts from 0 and read/write from bios.
This means that now we need bios for start a game.