### PR TITLE
Single data transfer fix

### DIFF
--- a/emu/src/arm/arm7tdmi.rs
+++ b/emu/src/arm/arm7tdmi.rs
@@ -32,7 +32,7 @@ impl Default for Arm7tdmi {
     fn default() -> Self {
         let mut s = Self {
             memory: Arc::new(Mutex::new(InternalMemory::default())),
-            cpsr: Psr::from(Mode::User), // FIXME: Starting as User? Not sure
+            cpsr: Psr::from(Mode::Supervisor), // FIXME: Starting as Supervisor? Not sure
             registers: Registers::default(),
             register_bank: RegisterBank::default(),
         };

--- a/emu/src/arm/data_processing.rs
+++ b/emu/src/arm/data_processing.rs
@@ -1095,6 +1095,7 @@ mod tests {
             let mut cpu = Arm7tdmi::default();
             let op_code = 0b1110_00010_0_001111_0000_000000000000;
             let op_code = cpu.decode(op_code);
+            cpu.cpsr.set_mode(Mode::User);
 
             cpu.cpsr.set_carry_flag(true);
             cpu.cpsr.set_overflow_flag(true);
@@ -1134,6 +1135,7 @@ mod tests {
             let mut cpu = Arm7tdmi::default();
             let op_code = 0b1110_00010_0_1010011111_00000000_0000;
             let op_code = cpu.decode(op_code);
+            cpu.cpsr.set_mode(Mode::User);
 
             cpu.registers.set_register_at(0, 0b1111 << 28);
 
@@ -1164,6 +1166,7 @@ mod tests {
             let mut cpu = Arm7tdmi::default();
             let op_code = 0b1110_00_0_10_0_1010001111_00000000_0000;
             let op_code = cpu.decode(op_code);
+            cpu.cpsr.set_mode(Mode::User);
 
             cpu.registers.set_register_at(0, 0b1111 << 28);
 


### PR DESCRIPTION
This should be merged after #129 .

* Fix a bug in `single_data_transfer` function: we were inverting the logic of the up/down bit
* Now cpu boots in supervisor mode (https://www.reddit.com/r/EmuDev/comments/6tr4fz/gba_does_anyone_have_any_information_on_the/ and https://www.cs.rit.edu/~tjh8300/CowBite/CowBiteSpec.htm#SVC). Not 100% sure yet but I think it's still better than booting in User mode :D