### PR TITLE
Revert increment after fetch + small fixes

### DIFF
--- a/emu/src/arm/arm7tdmi.rs
+++ b/emu/src/arm/arm7tdmi.rs
@@ -173,7 +173,7 @@ impl Arm7tdmi {
         self.cpsr.set_cpu_state(state);
         self.registers.set_program_counter(rn);
 
-        false
+        unimplemented!("We should implement THUMB mode first!");
     }
 
     fn data_transfer_register_offset(&mut self, op_code: ArmModeOpcode) -> bool {

--- a/emu/src/arm/data_processing.rs
+++ b/emu/src/arm/data_processing.rs
@@ -5,7 +5,10 @@ use crate::{
     bitwise::Bits,
 };
 
-use super::{arm7tdmi::REG_PROGRAM_COUNTER, cpu_modes::Mode};
+use super::{
+    arm7tdmi::{REG_PROGRAM_COUNTER, SIZE_OF_ARM_INSTRUCTION},
+    cpu_modes::Mode,
+};
 
 pub struct ArithmeticOpResult {
     result: u32,
@@ -328,7 +331,7 @@ impl Arm7tdmi {
         }
     }
 
-    pub fn data_processing(&mut self, op_code: ArmModeOpcode) -> bool {
+    pub fn data_processing(&mut self, op_code: ArmModeOpcode) -> Option<u32> {
         // bit [25] is I = Immediate Flag
         let i: bool = op_code.get_bit(25);
         // bits [24-21]
@@ -371,7 +374,7 @@ impl Arm7tdmi {
                 } else {
                     self.psr_transfer(op_code);
 
-                    return true;
+                    return Some(SIZE_OF_ARM_INSTRUCTION);
                 }
             }
             ArmModeAluInstruction::Teq => {
@@ -380,7 +383,7 @@ impl Arm7tdmi {
                 } else {
                     self.psr_transfer(op_code);
 
-                    return true;
+                    return Some(SIZE_OF_ARM_INSTRUCTION);
                 }
             }
             ArmModeAluInstruction::Cmp => {
@@ -389,7 +392,7 @@ impl Arm7tdmi {
                 } else {
                     self.psr_transfer(op_code);
 
-                    return true;
+                    return Some(SIZE_OF_ARM_INSTRUCTION);
                 }
             }
             ArmModeAluInstruction::Cmn => {
@@ -398,7 +401,7 @@ impl Arm7tdmi {
                 } else {
                     self.psr_transfer(op_code);
 
-                    return true;
+                    return Some(SIZE_OF_ARM_INSTRUCTION);
                 }
             }
             ArmModeAluInstruction::Orr => self.orr(rd.try_into().unwrap(), rn, op2, s),
@@ -412,8 +415,9 @@ impl Arm7tdmi {
             ArmModeAluInstruction::Teq
             | ArmModeAluInstruction::Cmp
             | ArmModeAluInstruction::Cmn
-            | ArmModeAluInstruction::Tst => true,
-            _ => rd != 0xF,
+            | ArmModeAluInstruction::Tst => Some(SIZE_OF_ARM_INSTRUCTION),
+            _ if rd != 0xF => Some(SIZE_OF_ARM_INSTRUCTION),
+            _ => None,
         }
     }
 

--- a/emu/src/arm/data_processing.rs
+++ b/emu/src/arm/data_processing.rs
@@ -292,8 +292,7 @@ impl Arm7tdmi {
                     // Should we set it? I guess software are written in order to not switch this bit
                     // but who knows?
                     // psr.set_state_bit(rm.get_bit(5));
-
-                    psr.set_mode(Mode::try_from(rm.get_bits(0..=4)).unwrap())
+                    psr.set_mode_raw(rm.get_bits(0..=4));
                 }
             }
             PsrOpKind::MsrFlg => {

--- a/emu/src/arm/psr.rs
+++ b/emu/src/arm/psr.rs
@@ -135,6 +135,14 @@ impl Psr {
         self.0.set_bit(5, value);
     }
 
+    pub fn set_mode_raw(&mut self, m: u32) {
+        self.0 &= 0b1111_1111_1111_1111_1111_1111_1110_0000;
+
+        let mode_raw = m & 0b0001_1111;
+
+        self.0 |= mode_raw;
+    }
+
     /// The Mode Bits M4-M0 contain the current operating mode.
     pub fn set_mode(&mut self, m: Mode) {
         // Setting mode bits to 0

--- a/emu/src/arm/single_data_transfer.rs
+++ b/emu/src/arm/single_data_transfer.rs
@@ -2,7 +2,7 @@ use crate::{
     arm::arm7tdmi::Arm7tdmi, arm::opcode::ArmModeOpcode, bitwise::Bits, memory::io_device::IoDevice,
 };
 
-use super::arm7tdmi::{Offsetting, REG_PROGRAM_COUNTER};
+use super::arm7tdmi::{Offsetting, REG_PROGRAM_COUNTER, SIZE_OF_ARM_INSTRUCTION};
 
 /// Possible opeartion on transfer data.
 #[derive(PartialEq)]
@@ -58,7 +58,7 @@ impl From<&ArmModeOpcode> for ReadWriteKind {
 }
 
 impl Arm7tdmi {
-    pub(crate) fn single_data_transfer(&mut self, op_code: ArmModeOpcode) -> bool {
+    pub(crate) fn single_data_transfer(&mut self, op_code: ArmModeOpcode) -> Option<u32> {
         let immediate = op_code.get_bit(25);
 
         let offsetting: Offsetting = op_code.get_bit(23).into();
@@ -127,7 +127,11 @@ impl Arm7tdmi {
         }
 
         // If LDR and Rd == R15 we don't increase the PC
-        !(load_store == SingleDataTransfer::Ldr && rd == REG_PROGRAM_COUNTER)
+        if !(load_store == SingleDataTransfer::Ldr && rd == REG_PROGRAM_COUNTER) {
+            Some(SIZE_OF_ARM_INSTRUCTION)
+        } else {
+            None
+        }
     }
 }
 

--- a/emu/src/memory/internal_memory.rs
+++ b/emu/src/memory/internal_memory.rs
@@ -6,6 +6,8 @@ use crate::memory::io_device::IoDevice;
 use crate::memory::lcd_registers::LCDRegisters;
 use crate::memory::timer_registers::TimerRegisters;
 
+use super::interrupts::Interrupts;
+
 pub struct InternalMemory {
     /// From 0x00000000 to 0x00003FFF (16 KBytes).
     bios_system_rom: Vec<u8>,
@@ -21,6 +23,9 @@ pub struct InternalMemory {
 
     /// From 0x04000100 to 0x0400010E.
     timer_registers: TimerRegisters,
+
+    /// From 0x04000200 to 040003FE
+    interrupts: Interrupts,
 
     /// From 0x05000000 to  0x050001FF (512 bytes, 256 colors).
     pub bg_palette_ram: Vec<u8>,
@@ -58,11 +63,12 @@ impl InternalMemory {
             bios_system_rom: bios.into(),
             working_ram: vec![0; 0x00040000],
             working_iram: vec![0; 0x00008000],
+            lcd_registers: LCDRegisters::default(),
+            timer_registers: TimerRegisters::default(),
+            interrupts: Interrupts::default(),
             bg_palette_ram: vec![0; 0x200],
             obj_palette_ram: vec![0; 0x200],
             video_ram: vec![0; 0x00018000],
-            lcd_registers: LCDRegisters::new(),
-            timer_registers: TimerRegisters::new(),
             rom,
             unused_region: HashMap::new(),
         }
@@ -80,6 +86,7 @@ impl IoDevice for InternalMemory {
             0x03000000..=0x03007FFF => self.working_iram[address - 0x03000000],
             0x04000000..=0x04000055 => self.lcd_registers.read_at(address),
             0x04000100..=0x0400010E => self.timer_registers.read_at(address),
+            0x04000200..=0x040003FE => self.interrupts.read_at(address),
             0x05000000..=0x050001FF => self.bg_palette_ram[address - 0x05000000],
             0x05000200..=0x050003FF => self.obj_palette_ram[address - 0x05000200],
             0x06000000..=0x06017FFF => self.video_ram[address - 0x06000000],
@@ -101,6 +108,7 @@ impl IoDevice for InternalMemory {
             0x03000000..=0x03007FFF => self.working_iram[address - 0x03000000] = value,
             0x04000000..=0x04000055 => self.lcd_registers.write_at(address, value),
             0x04000100..=0x0400010E => self.timer_registers.write_at(address, value),
+            0x04000200..=0x040003FE => self.interrupts.write_at(address, value),
             0x05000000..=0x050001FF => self.bg_palette_ram[address - 0x05000000] = value,
             0x05000200..=0x050003FF => self.obj_palette_ram[address - 0x05000200] = value,
             0x06000000..=0x06017FFF => self.video_ram[address - 0x06000000] = value,

--- a/emu/src/memory/interrupts.rs
+++ b/emu/src/memory/interrupts.rs
@@ -1,0 +1,65 @@
+use crate::{
+    bitwise::Bits,
+    memory::io_registers::{IORegister, IORegisterAccessControl},
+};
+
+use super::io_device::IoDevice;
+
+pub struct Interrupts {
+    //   4000200h  2    R/W  IE        Interrupt Enable Register
+    //   4000202h  2    R/W  IF        Interrupt Request Flags / IRQ Acknowledge
+    //   4000204h  2    R/W  WAITCNT   Game Pak Waitstate Control
+    //   4000206h       -    -         Not used
+    /// Interrupt Master Enable Register
+    ime: IORegister,
+    //   400020Ah       -    -         Not used
+    /// Post boot flag.
+    post_flag: IORegister,
+    //   4000301h  1    W    HALTCNT   Undocumented - Power Down Control
+    //   4000302h       -    -         Not used
+    //   4000410h  ?    ?    ?         Undocumented - Purpose Unknown / Bug ??? 0FFh
+    //   4000411h       -    -         Not used
+    //   4000800h  4    R/W  ?         Undocumented - Internal Memory Control (R/W)
+    //   4000804h       -    -         Not used
+    //   4xx0800h  4    R/W  ?         Mirrors of 4000800h (repeated each 64K)
+}
+
+impl Default for Interrupts {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Interrupts {
+    pub const fn new() -> Self {
+        use IORegisterAccessControl::*;
+
+        Self {
+            post_flag: IORegister::with_access_control(ReadWrite),
+            ime: IORegister::with_access_control(ReadWrite),
+        }
+    }
+}
+
+impl IoDevice for Interrupts {
+    type Address = usize;
+    type Value = u8;
+
+    fn read_at(&self, address: usize) -> u8 {
+        match address {
+            0x04000300 => self.post_flag.read().get_byte(0),
+            0x04000208 => self.ime.read().get_byte(0),
+            0x04000209 => self.ime.read().get_byte(1),
+            _ => panic!("Reading an write-only memory address: {address:x}"),
+        }
+    }
+
+    fn write_at(&mut self, address: usize, value: u8) {
+        match address {
+            0x04000300 => self.post_flag.set_byte(0, value),
+            0x04000208 => self.ime.set_byte(0, value),
+            0x04000209 => self.ime.set_byte(1, value),
+            _ => panic!("Writing an read-only memory address: {address:x}"),
+        }
+    }
+}

--- a/emu/src/memory/mod.rs
+++ b/emu/src/memory/mod.rs
@@ -1,5 +1,6 @@
 pub mod internal_memory;
+mod interrupts;
 pub mod io_device;
-pub mod io_registers;
-pub mod lcd_registers;
-pub mod timer_registers;
+mod io_registers;
+mod lcd_registers;
+mod timer_registers;


### PR DESCRIPTION
To be merged after #134 .

This PR mainly reverts the increment after fetch commit.

I also changed the `MSR` instruction to use `set_mode_raw`, directly setting the mode bits, this is because the BIOS wants to execute:
<img width="155" alt="image" src="https://user-images.githubusercontent.com/5256712/205486616-301111d0-b27d-441a-a52c-8eb0e3e53a16.png">
And it was failing since it was trying to do `set_mode(Mode::try_from(0b00000).unwrap())` (`0b00000` is not a mode). But if the BIOS wants to do it we should let it do :D

I've also added a panic in the `branch_and_exchange` as we don't have the THUMB mode yet, thus every instruction executed after the `branch_and_exchanged` is meaningless (the bios was looping).
