### PR TITLE
Small fixes in thumb/bx

### DIFF
--- a/emu/src/arm/arm7tdmi.rs
+++ b/emu/src/arm/arm7tdmi.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 use logger::log;
 
 use crate::arm::cpu_modes::Mode;
-use crate::arm::instruction::ArmModeInstruction;
+use crate::arm::instruction::{ArmModeInstruction, ThumbModeInstruction};
 use crate::arm::opcode::ArmModeOpcode;
 use crate::arm::psr::Psr;
 use crate::arm::register_bank::RegisterBank;
@@ -99,14 +99,35 @@ impl Arm7tdmi {
             .advance_program_counter(bytes_to_advance.unwrap_or(0));
     }
 
-    #[allow(clippy::match_single_binding)]
+    #[allow(unreachable_code)]
+    #[allow(unused_variables)]
     pub fn execute_thumb(&mut self, op_code: ThumbModeOpcode) {
-        let bytes_to_advance = match op_code.instruction {
-            // TODO: implement instructions
-            _ => 2,
+        use ThumbModeInstruction::*;
+
+        let bytes_to_advance: Option<u32> = match op_code.instruction {
+            MoveShiftedRegister => unimplemented!(),
+            AddSubtract => unimplemented!(),
+            MoveCompareAddSubtractImm => unimplemented!(),
+            AluOp => unimplemented!(),
+            HiRegisterOpBX => unimplemented!(),
+            PCRelativeLoad => unimplemented!(),
+            LoadStoreRegisterOffset => unimplemented!(),
+            LoadStoreSignExtByteHalfword => unimplemented!(),
+            LoadStoreImmOffset => unimplemented!(),
+            LoadStoreHalfword => unimplemented!(),
+            SPRelativeLoadStore => unimplemented!(),
+            LoadAddress => unimplemented!(),
+            AddOffsetSP => unimplemented!(),
+            PushPopReg => unimplemented!(),
+            MultipleLoadStore => unimplemented!(),
+            CondBranch => unimplemented!(),
+            Swi => unimplemented!(),
+            UncondBranch => unimplemented!(),
+            LongBranchLink => unimplemented!(),
         };
 
-        self.registers.advance_program_counter(bytes_to_advance);
+        self.registers
+            .advance_program_counter(bytes_to_advance.unwrap_or(0));
     }
 
     pub fn step(&mut self) {

--- a/emu/src/arm/arm7tdmi.rs
+++ b/emu/src/arm/arm7tdmi.rs
@@ -131,13 +131,25 @@ impl Arm7tdmi {
     }
 
     pub fn step(&mut self) {
+        // We set pc lowest bits to 0. In ARM we set the 2 lsb to 0 because instructions are word aligned.
+        // In THUMB we set only the lsb to 0 because instructions are halfword aligned.
+
         match self.cpsr.cpu_state() {
             CpuState::Thumb => {
+                let mut pc = self.registers.program_counter() as u32;
+                pc.set_bit_off(0);
+                self.registers.set_program_counter(pc);
+
                 let op = self.fetch_thumb();
                 let op = self.decode(op);
                 self.execute_thumb(op);
             }
             CpuState::Arm => {
+                let mut pc = self.registers.program_counter() as u32;
+                pc.set_bit_off(0);
+                pc.set_bit_off(1);
+                self.registers.set_program_counter(pc);
+
                 let op = self.fetch_arm();
                 let op = self.decode(op);
                 self.execute_arm(op);

--- a/emu/src/arm/arm7tdmi.rs
+++ b/emu/src/arm/arm7tdmi.rs
@@ -192,11 +192,12 @@ impl Arm7tdmi {
 
     fn branch_and_exchange(&mut self, op_code: ArmModeOpcode) -> Option<u32> {
         let rn = op_code.get_bits(0..=3);
+        let rn = self.registers.register_at(rn.try_into().unwrap());
         let state: CpuState = rn.get_bit(0).into();
         self.cpsr.set_cpu_state(state);
         self.registers.set_program_counter(rn);
 
-        unimplemented!("We should implement THUMB mode first!");
+        None
     }
 
     fn data_transfer_register_offset(&mut self, op_code: ArmModeOpcode) -> Option<u32> {

--- a/emu/src/arm/data_processing.rs
+++ b/emu/src/arm/data_processing.rs
@@ -1125,7 +1125,7 @@ mod tests {
 
             assert_eq!(
                 cpu.registers.register_at(0),
-                0b1111_00000000000000000000_001_10000
+                0b1111_00000000000000000000_000_10000
             );
         }
         {
@@ -1161,7 +1161,7 @@ mod tests {
             cpu.execute_arm(op_code);
 
             // All flags set and User mode
-            assert_eq!(u32::from(cpu.cpsr), 0b1111 << 28 | (0b110000));
+            assert_eq!(u32::from(cpu.cpsr), 0b1111 << 28 | (0b10000));
         }
         {
             // Covers MSR with SPSR_fiq
@@ -1192,7 +1192,7 @@ mod tests {
             cpu.execute_arm(op_code);
 
             // All flags set and User mode
-            assert_eq!(u32::from(cpu.cpsr), 0b1111 << 28 | (0b110000));
+            assert_eq!(u32::from(cpu.cpsr), 0b1111 << 28 | (0b10000));
         }
         {
             // Covers MSR-flags with SPSR_fiq

--- a/emu/src/arm/instruction.rs
+++ b/emu/src/arm/instruction.rs
@@ -87,13 +87,73 @@ impl Display for ArmModeInstruction {
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum ThumbModeInstruction {
-    Dummy,
+    MoveShiftedRegister,
+    AddSubtract,
+    MoveCompareAddSubtractImm,
+    AluOp,
+    HiRegisterOpBX,
+    PCRelativeLoad,
+    LoadStoreRegisterOffset,
+    LoadStoreSignExtByteHalfword,
+    LoadStoreImmOffset,
+    LoadStoreHalfword,
+    SPRelativeLoadStore,
+    LoadAddress,
+    AddOffsetSP,
+    PushPopReg,
+    MultipleLoadStore,
+    CondBranch,
+    Swi,
+    UncondBranch,
+    LongBranchLink,
 }
 
 impl From<u16> for ThumbModeInstruction {
-    fn from(_: u16) -> Self {
-        // TODO: Implement instructions
-        Self::Dummy
+    fn from(op_code: u16) -> Self {
+        use ThumbModeInstruction::*;
+
+        if op_code.get_bits(8..=15) == 0b11011111 {
+            Swi
+        } else if op_code.get_bits(8..=15) == 0b10110000 {
+            AddOffsetSP
+        } else if op_code.get_bits(10..=15) == 0b010000 {
+            AluOp
+        } else if op_code.get_bits(10..=15) == 0b010001 {
+            HiRegisterOpBX
+        } else if op_code.get_bits(12..=15) == 0b1011 && op_code.get_bits(9..=10) == 0b10 {
+            PushPopReg
+        } else if op_code.get_bits(11..=15) == 0b00011 {
+            AddSubtract
+        } else if op_code.get_bits(11..=15) == 0b01001 {
+            PCRelativeLoad
+        } else if op_code.get_bits(12..=15) == 0b0101 && !op_code.get_bit(9) {
+            LoadStoreRegisterOffset
+        } else if op_code.get_bits(12..=15) == 0b0101 && op_code.get_bit(9) {
+            LoadStoreSignExtByteHalfword
+        } else if op_code.get_bits(11..=15) == 0b11100 {
+            UncondBranch
+        } else if op_code.get_bits(12..=15) == 0b1000 {
+            LoadStoreHalfword
+        } else if op_code.get_bits(12..=15) == 0b1001 {
+            SPRelativeLoadStore
+        } else if op_code.get_bits(12..=15) == 0b1010 {
+            LoadAddress
+        } else if op_code.get_bits(12..=15) == 0b1100 {
+            MultipleLoadStore
+        } else if op_code.get_bits(12..=15) == 0b1101 {
+            CondBranch
+        } else if op_code.get_bits(12..=15) == 0b1111 {
+            LongBranchLink
+        } else if op_code.get_bits(13..=15) == 0b000 {
+            MoveShiftedRegister
+        } else if op_code.get_bits(13..=15) == 0b001 {
+            MoveCompareAddSubtractImm
+        } else if op_code.get_bits(13..=15) == 0b011 {
+            LoadStoreImmOffset
+        } else {
+            log("not identified instruction");
+            unimplemented!()
+        }
     }
 }
 

--- a/emu/src/arm/opcode.rs
+++ b/emu/src/arm/opcode.rs
@@ -117,7 +117,7 @@ impl Display for ThumbModeOpcode {
         };
 
         let mut raw_bits = String::new();
-        for i in format!("{:#034b}", self.raw).chars().skip(2) {
+        for i in format!("{:#018b}", self.raw).chars().skip(2) {
             raw_bits.push(i);
             raw_bits.push('_');
         }

--- a/emu/src/arm/psr.rs
+++ b/emu/src/arm/psr.rs
@@ -198,8 +198,8 @@ pub enum CpuState {
 impl From<CpuState> for bool {
     fn from(state: CpuState) -> Self {
         match state {
-            CpuState::Arm => true,
-            CpuState::Thumb => false,
+            CpuState::Arm => false,
+            CpuState::Thumb => true,
         }
     }
 }
@@ -207,8 +207,8 @@ impl From<CpuState> for bool {
 impl From<bool> for CpuState {
     fn from(state: bool) -> Self {
         match state {
-            false => Self::Thumb,
-            true => Self::Arm,
+            true => Self::Thumb,
+            false => Self::Arm,
         }
     }
 }


### PR DESCRIPTION
* `CpuState` was using the inverted logic
* `BX` was not reading the value from `Rn`
* Added instruction decode for THUMB mode
* Setting lsb in PC to 0 before fetching
<img width="462" alt="image" src="https://user-images.githubusercontent.com/5256712/206325118-aeaff88e-71ff-417a-a6e2-2e995d3d1807.png">
