### PR TITLE
THUMB: Implement `Load/Store Register offset` instruction

### DIFF
--- a/emu/src/bitwise.rs
+++ b/emu/src/bitwise.rs
@@ -60,12 +60,23 @@ where
     }
 
     fn get_bits(&self, bits_range: RangeInclusive<u8>) -> Self {
-        let mut bits = 0b0;
-        for (shift_value, bit_index) in bits_range.enumerate() {
-            let bit_value: u128 = self.get_bit(bit_index).into();
-            bits |= bit_value << shift_value;
-        }
-        bits.try_into().unwrap()
+        let start = bits_range.start();
+        let length = bits_range.len() as u32;
+
+        // Gets a value with `length` number of ones.
+        // If bits_range is 1..=10 then length is 10 and we want
+        // 10 ones.
+        let mut mask = (2_u128.pow(length)) - 1;
+
+        // Moves the mask to the correct place.
+        // If `bits_range` is 1..=10 then we should move the mask
+        // 1 bit to the left in order to get from the first bit on.
+        mask <<= start;
+
+        let value: u128 = <Self as Into<u128>>::into(self.clone());
+
+        // We apply the mask and then move the value back to the 0 position.
+        <Self as TryFrom<u128>>::try_from((value & mask) >> start).unwrap()
     }
 
     /// Checks if a certein sequence of bit is set to 1.

--- a/emu/src/cpu/arm7tdmi.rs
+++ b/emu/src/cpu/arm7tdmi.rs
@@ -12,28 +12,14 @@ use crate::cpu::register_bank::RegisterBank;
 use crate::memory::internal_memory::InternalMemory;
 use crate::memory::io_device::IoDevice;
 
+use super::flags::{Indexing, LoadStoreKind, Offsetting, ReadWriteKind};
 use super::opcode::ThumbModeOpcode;
 use super::psr::CpuState;
 use super::registers::Registers;
-use super::single_data_transfer::ReadWriteKind;
 
 pub const REG_PROGRAM_COUNTER: u32 = 0xF;
 pub const SIZE_OF_ARM_INSTRUCTION: u32 = 4;
 pub const SIZE_OF_THUMB_INSTRUCTION: u32 = 2;
-
-enum LoadStoreKind {
-    Store,
-    Load,
-}
-
-impl From<bool> for LoadStoreKind {
-    fn from(b: bool) -> Self {
-        match b {
-            false => Self::Store,
-            true => Self::Load,
-        }
-    }
-}
 
 pub struct Arm7tdmi {
     pub(crate) memory: Arc<Mutex<InternalMemory>>,
@@ -169,41 +155,6 @@ impl Arm7tdmi {
                 let op = self.decode(op);
                 self.execute_arm(op);
             }
-        }
-    }
-}
-
-#[derive(PartialEq)]
-enum Indexing {
-    /// Add offset after transfer.
-    Post,
-
-    /// Add offset before transfer.
-    Pre,
-}
-
-impl From<bool> for Indexing {
-    fn from(state: bool) -> Self {
-        match state {
-            false => Self::Post,
-            true => Self::Pre,
-        }
-    }
-}
-
-pub enum Offsetting {
-    /// Substract the offset from base.
-    Down,
-
-    /// Add the offset to base.
-    Up,
-}
-
-impl From<bool> for Offsetting {
-    fn from(state: bool) -> Self {
-        match state {
-            false => Self::Down,
-            true => Self::Up,
         }
     }
 }

--- a/emu/src/cpu/flags.rs
+++ b/emu/src/cpu/flags.rs
@@ -1,0 +1,79 @@
+use crate::bitwise::Bits;
+
+use super::opcode::ArmModeOpcode;
+
+/// There two different kind of write or read for memory.
+#[derive(Default)]
+pub enum ReadWriteKind {
+    /// Word is a u32 value for ARM mode and u16 for Thumb mode.
+    #[default]
+    Word,
+
+    /// Byte is a u8 value.
+    Byte,
+}
+
+impl From<bool> for ReadWriteKind {
+    fn from(value: bool) -> Self {
+        if value {
+            Self::Byte
+        } else {
+            Self::Word
+        }
+    }
+}
+
+impl From<&ArmModeOpcode> for ReadWriteKind {
+    fn from(op_code: &ArmModeOpcode) -> Self {
+        op_code.get_bit(22).into()
+    }
+}
+
+pub enum LoadStoreKind {
+    Store,
+    Load,
+}
+
+impl From<bool> for LoadStoreKind {
+    fn from(b: bool) -> Self {
+        match b {
+            false => Self::Store,
+            true => Self::Load,
+        }
+    }
+}
+
+#[derive(PartialEq, Eq)]
+pub enum Indexing {
+    /// Add offset after transfer.
+    Post,
+
+    /// Add offset before transfer.
+    Pre,
+}
+
+impl From<bool> for Indexing {
+    fn from(state: bool) -> Self {
+        match state {
+            false => Self::Post,
+            true => Self::Pre,
+        }
+    }
+}
+
+pub enum Offsetting {
+    /// Substract the offset from base.
+    Down,
+
+    /// Add the offset to base.
+    Up,
+}
+
+impl From<bool> for Offsetting {
+    fn from(state: bool) -> Self {
+        match state {
+            false => Self::Down,
+            true => Self::Up,
+        }
+    }
+}

--- a/emu/src/cpu/mod.rs
+++ b/emu/src/cpu/mod.rs
@@ -3,6 +3,7 @@ pub mod arm7tdmi;
 mod condition;
 mod cpu_modes;
 mod data_processing;
+mod flags;
 mod instruction;
 mod move_compare_add_sub;
 mod opcode;

--- a/emu/src/cpu/opcode.rs
+++ b/emu/src/cpu/opcode.rs
@@ -128,7 +128,9 @@ impl Display for ThumbModeOpcode {
             ThumbModeInstruction::AluOp => todo!(),
             ThumbModeInstruction::HiRegisterOpBX => todo!(),
             ThumbModeInstruction::PCRelativeLoad => "FMT: |0_1_0_0_1|_Rn__|_____Word8_____|",
-            ThumbModeInstruction::LoadStoreRegisterOffset => todo!(),
+            ThumbModeInstruction::LoadStoreRegisterOffset => {
+                "FMT: |0_1_0_1|L|B|0|_Ro__|_Rb__|_Rd__|"
+            }
             ThumbModeInstruction::LoadStoreSignExtByteHalfword => todo!(),
             ThumbModeInstruction::LoadStoreImmOffset => todo!(),
             ThumbModeInstruction::LoadStoreHalfword => todo!(),

--- a/emu/src/cpu/single_data_transfer.rs
+++ b/emu/src/cpu/single_data_transfer.rs
@@ -32,7 +32,7 @@ impl From<ArmModeOpcode> for SingleDataTransfer {
 
 /// There two different kind of write or read for memory.
 #[derive(Default)]
-enum ReadWriteKind {
+pub enum ReadWriteKind {
     /// Word is a u32 value for ARM mode and u16 for Thumb mode.
     #[default]
     Word,

--- a/emu/src/cpu/single_data_transfer.rs
+++ b/emu/src/cpu/single_data_transfer.rs
@@ -2,7 +2,10 @@ use crate::{
     bitwise::Bits, cpu::arm7tdmi::Arm7tdmi, cpu::opcode::ArmModeOpcode, memory::io_device::IoDevice,
 };
 
-use super::arm7tdmi::{Offsetting, REG_PROGRAM_COUNTER, SIZE_OF_ARM_INSTRUCTION};
+use super::{
+    arm7tdmi::{REG_PROGRAM_COUNTER, SIZE_OF_ARM_INSTRUCTION},
+    flags::{Offsetting, ReadWriteKind},
+};
 
 /// Possible opeartion on transfer data.
 #[derive(PartialEq)]
@@ -27,33 +30,6 @@ impl From<ArmModeOpcode> for SingleDataTransfer {
         } else {
             Self::Str
         }
-    }
-}
-
-/// There two different kind of write or read for memory.
-#[derive(Default)]
-pub enum ReadWriteKind {
-    /// Word is a u32 value for ARM mode and u16 for Thumb mode.
-    #[default]
-    Word,
-
-    /// Byte is a u8 value.
-    Byte,
-}
-
-impl From<bool> for ReadWriteKind {
-    fn from(value: bool) -> Self {
-        if value {
-            Self::Byte
-        } else {
-            Self::Word
-        }
-    }
-}
-
-impl From<&ArmModeOpcode> for ReadWriteKind {
-    fn from(op_code: &ArmModeOpcode) -> Self {
-        op_code.get_bit(22).into()
     }
 }
 

--- a/emu/src/memory/internal_memory.rs
+++ b/emu/src/memory/internal_memory.rs
@@ -344,6 +344,14 @@ mod tests {
     }
 
     #[test]
+    fn check_read_word() {
+        let mut im = InternalMemory::default();
+        im.bios_system_rom = vec![0x12, 0x34, 0x56, 0x78];
+
+        assert_eq!(im.read_word(0), 0x78563412);
+    }
+
+    #[test]
     fn check_write_word() {
         let mut im = InternalMemory::default();
         im.write_word(0, 0x12345678);


### PR DESCRIPTION
* Add `write_word` function to internal memory
* Implement instruction
* Rewrote `get_bits` in order to avoid using `for` and using binary arithmetics instead. It's faster than 50% on `u32` (but this 50% is only 20ns, lol).

Should we move `ReadWriteKind` somewhere else since it's not used only by `single_data_transfer`?