### PR TITLE
Register Bank fix. Fix MSR op

### DIFF
--- a/emu/src/cpu/register_bank.rs
+++ b/emu/src/cpu/register_bank.rs
@@ -2,6 +2,13 @@ use crate::cpu::psr::Psr;
 
 #[derive(Default)]
 pub struct RegisterBank {
+    pub r8_old: u32,
+    pub r9_old: u32,
+    pub r10_old: u32,
+    pub r11_old: u32,
+    pub r12_old: u32,
+    pub r13_old: u32,
+    pub r14_old: u32,
     pub r8_fiq: u32,
     pub r9_fiq: u32,
     pub r10_fiq: u32,


### PR DESCRIPTION
Merge after #146 

* Fix mode swapping and register bank logic
Before, we were using the different SPSR_{mode} as saved versions
of CPSR. This is wrong, the correct way of doing is that every mode
(except System and User) have their SPSR, separate from the CPSR.
So, the SPSR is just another register (analogous to the CPSR) that gets
banked for every mode.
Another problem was also that we were not saving/restoring the "base"
r8-14 registers. So for example when going from System to FIQ, FIQ
was replacing r8-14 with its own versions. Then, if the system would
have gone from FIQ to System the old values of r8-14 would have not
been restored.

* ARM: Fix MSR op
Now it correctly stores/restores banked registers.

