### PR TITLE
Thumb: Implement LSL for shift

### DIFF
--- a/emu/src/cpu/alu_instruction.rs
+++ b/emu/src/cpu/alu_instruction.rs
@@ -138,6 +138,15 @@ impl From<u32> for ShiftKind {
     }
 }
 
+#[derive(Default)]
+pub struct ArithmeticOpResult {
+    pub result: u32,
+    pub carry: bool,
+    pub overflow: bool,
+    pub sign: bool,
+    pub zero: bool,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/emu/src/cpu/alu_instruction.rs
+++ b/emu/src/cpu/alu_instruction.rs
@@ -1,3 +1,5 @@
+use crate::bitwise::Bits;
+
 pub enum ArmModeAluInstruction {
     And = 0x0,
     Eor = 0x1,
@@ -145,6 +147,35 @@ pub struct ArithmeticOpResult {
     pub overflow: bool,
     pub sign: bool,
     pub zero: bool,
+}
+
+pub fn shift(kind: ShiftKind, shift_amount: u32, rm: u32, carry: bool) -> ArithmeticOpResult {
+    match kind {
+        ShiftKind::Lsl => {
+            match shift_amount {
+                // LSL#0: No shift performed, ie. directly value=Rm, the C flag is NOT affected.
+                0 => ArithmeticOpResult {
+                    result: rm,
+                    carry,
+                    ..Default::default()
+                },
+                // LSL#1..32: Normal left logical shift
+                1..=32 => ArithmeticOpResult {
+                    result: rm << shift_amount,
+                    carry: rm.get_bit((32 - shift_amount).try_into().unwrap()),
+                    ..Default::default()
+                },
+                // LSL#33...: Result is 0 and carry is 0
+                _ => ArithmeticOpResult {
+                    carry: false,
+                    ..Default::default()
+                },
+            }
+        }
+        ShiftKind::Lsr => todo!(),
+        ShiftKind::Asr => todo!(),
+        ShiftKind::Ror => todo!(),
+    }
 }
 
 #[cfg(test)]

--- a/emu/src/cpu/alu_instruction.rs
+++ b/emu/src/cpu/alu_instruction.rs
@@ -107,6 +107,37 @@ impl From<u16> for ThumbModeAluInstruction {
     }
 }
 
+pub enum ShiftKind {
+    Lsl,
+    Lsr,
+    Asr,
+    Ror,
+}
+
+impl From<u16> for ShiftKind {
+    fn from(op: u16) -> Self {
+        match op {
+            0 => Self::Lsl,
+            1 => Self::Lsr,
+            2 => Self::Asr,
+            3 => Self::Ror,
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl From<u32> for ShiftKind {
+    fn from(op: u32) -> Self {
+        match op {
+            0 => Self::Lsl,
+            1 => Self::Lsr,
+            2 => Self::Asr,
+            3 => Self::Ror,
+            _ => unreachable!(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/emu/src/cpu/data_processing.rs
+++ b/emu/src/cpu/data_processing.rs
@@ -8,18 +8,11 @@ use crate::{
 };
 
 use super::{
+    alu_instruction::{self, ArithmeticOpResult},
     arm7tdmi::{REG_PROGRAM_COUNTER, SIZE_OF_ARM_INSTRUCTION},
     cpu_modes::Mode,
     flags::OperandKind,
 };
-
-pub struct ArithmeticOpResult {
-    pub result: u32,
-    pub carry: bool,
-    pub overflow: bool,
-    pub sign: bool,
-    pub zero: bool,
-}
 
 /// Represents the kind of PSR operation
 enum PsrOpKind {

--- a/emu/src/cpu/psr.rs
+++ b/emu/src/cpu/psr.rs
@@ -1,5 +1,7 @@
 use crate::bitwise::Bits;
-use crate::cpu::{condition::Condition, cpu_modes::Mode, data_processing::ArithmeticOpResult};
+use crate::cpu::{condition::Condition, cpu_modes::Mode};
+
+use super::alu_instruction::ArithmeticOpResult;
 
 /// Program Status Register.
 #[derive(Default, Clone, Copy)]


### PR DESCRIPTION
- CPU: Create `ShifKind` for u32/u16 conversion
- CPU: Move `ArithmeticOpResult` into alu_instruction module
- Thumb: Implement `LSL` for shift register
