### PR TITLE
THUMB: Add `Load\Store sign-ext halfword`

### DIFF
--- a/emu/src/cpu/opcode.rs
+++ b/emu/src/cpu/opcode.rs
@@ -131,7 +131,9 @@ impl Display for ThumbModeOpcode {
             ThumbModeInstruction::LoadStoreRegisterOffset => {
                 "FMT: |0_1_0_1|L|B|0|_Ro__|_Rb__|_Rd__|"
             }
-            ThumbModeInstruction::LoadStoreSignExtByteHalfword => todo!(),
+            ThumbModeInstruction::LoadStoreSignExtByteHalfword { .. } => {
+                "FMT: |0_1_0_1|H|S|1|_Ro__|_Rb__|_Rd__|"
+            }
             ThumbModeInstruction::LoadStoreImmOffset => "FMT: |0_1_1|B|L|_Offset5_|_Rb__|_Rd__|",
             ThumbModeInstruction::LoadStoreHalfword => "FMT: |1_0_0_0|L|_Offset5_|_Rb__|_Rd__|",
             ThumbModeInstruction::SPRelativeLoadStore => "FMT: |1_0_0_1|L|_Rd__|_____Word8_____|",


### PR DESCRIPTION
Should we move `disassemble` function to a trait?