### PR TITLE
Alu `cmp` for THUMB, Fix `tst` for THUMB, Memory regions

### DIFF
--- a/emu/src/cpu/arm7tdmi.rs
+++ b/emu/src/cpu/arm7tdmi.rs
@@ -1040,7 +1040,9 @@ impl Arm7tdmi {
             ThumbModeAluInstruction::Adc => todo!(),
             ThumbModeAluInstruction::Sbc => todo!(),
             ThumbModeAluInstruction::Ror => todo!(),
-            ThumbModeAluInstruction::Tst => self.tst(rd.into(), rs),
+            ThumbModeAluInstruction::Tst => {
+                self.tst(self.registers.register_at(rd.try_into().unwrap()), rs)
+            }
             ThumbModeAluInstruction::Neg => todo!(),
             ThumbModeAluInstruction::Cmp => {
                 self.cmp(self.registers.register_at(rd.try_into().unwrap()), rs)

--- a/emu/src/cpu/arm7tdmi.rs
+++ b/emu/src/cpu/arm7tdmi.rs
@@ -1042,7 +1042,9 @@ impl Arm7tdmi {
             ThumbModeAluInstruction::Ror => todo!(),
             ThumbModeAluInstruction::Tst => self.tst(rd.into(), rs),
             ThumbModeAluInstruction::Neg => todo!(),
-            ThumbModeAluInstruction::Cmp => todo!(),
+            ThumbModeAluInstruction::Cmp => {
+                self.cmp(self.registers.register_at(rd.try_into().unwrap()), rs)
+            }
             ThumbModeAluInstruction::Cmn => todo!(),
             ThumbModeAluInstruction::Orr => self.orr(
                 rd.into(),

--- a/emu/src/cpu/data_processing.rs
+++ b/emu/src/cpu/data_processing.rs
@@ -588,7 +588,7 @@ impl Arm7tdmi {
         self.cpsr.set_zero_flag(value == 0);
     }
 
-    fn cmp(&mut self, rn: u32, op2: u32) {
+    pub fn cmp(&mut self, rn: u32, op2: u32) {
         let sub_result = Self::sub_inner_op(rn, op2);
 
         self.cpsr.set_flags(sub_result);

--- a/emu/src/memory/internal_memory.rs
+++ b/emu/src/memory/internal_memory.rs
@@ -121,7 +121,10 @@ impl IoDevice for InternalMemory {
             0x06000000..=0x06017FFF => self.video_ram[address - 0x06000000],
             0x07000000..=0x070003FF => self.obj_attributes[address - 0x07000000],
             0x08000000..=0x0FFFFFFF => self.rom[address - 0x08000000],
-            0x03008000..=0x03FFFFFF | 0x00004000..=0x01FFFFFF | 0x10000000..=0xFFFFFFFF => {
+            0x03008000..=0x03FFFFFF
+            | 0x00004000..=0x01FFFFFF
+            | 0x10000000..=0xFFFFFFFF
+            | 0x06018000..=0x06FFFFFF => {
                 log(format!("read on unused memory {address:x}"));
                 self.unused_region.get(&address).map_or(0, |v| *v)
             }
@@ -145,7 +148,10 @@ impl IoDevice for InternalMemory {
             0x05000200..=0x050003FF => self.obj_palette_ram[address - 0x05000200] = value,
             0x06000000..=0x06017FFF => self.video_ram[address - 0x06000000] = value,
             0x07000000..=0x070003FF => self.obj_attributes[address - 0x07000000] = value,
-            0x03008000..=0x03FFFFFF | 0x00004000..=0x01FFFFFF | 0x10000000..=0xFFFFFFFF => {
+            0x03008000..=0x03FFFFFF
+            | 0x00004000..=0x01FFFFFF
+            | 0x10000000..=0xFFFFFFFF
+            | 0x06018000..=0x06FFFFFF => {
                 log("write on unused memory");
                 if self.unused_region.insert(address, value).is_some() {}
             }

--- a/emu/src/memory/interrupts.rs
+++ b/emu/src/memory/interrupts.rs
@@ -26,6 +26,7 @@ pub struct Interrupts {
     /// Post boot flag.
     post_flag: IORegister,
     //   4000301h  1    W    HALTCNT   Undocumented - Power Down Control
+    power_down_control: IORegister,
     //   4000302h       -    -         Not used
     //   4000410h  ?    ?    ?         Undocumented - Purpose Unknown / Bug ??? 0FFh
     purpose_unknown: IORegister,
@@ -51,6 +52,7 @@ impl Interrupts {
             interrupt_request: IORegister::with_access_control(ReadWrite),
             wait_state: IORegister::with_access_control(ReadWrite),
             post_flag: IORegister::with_access_control(ReadWrite),
+            power_down_control: IORegister::with_access_control(ReadWrite),
             ime: IORegister::with_access_control(ReadWrite),
             purpose_unknown: IORegister::with_access_control(ReadWrite),
             unused_region: HashMap::new(),
@@ -94,9 +96,10 @@ impl IoDevice for Interrupts {
                 log("write on unused memory");
                 self.unused_region.insert(address, value);
             }
-            0x04000300 => self.post_flag.set_byte(0, value),
             0x04000208 => self.ime.set_byte(0, value),
             0x04000209 => self.ime.set_byte(1, value),
+            0x04000300 => self.post_flag.set_byte(0, value),
+            0x04000301 => self.power_down_control.set_byte(0, value),
             0x04000410 => self.purpose_unknown.set_byte(0, value),
             _ => panic!("Writing an read-only memory address: {address:x}"),
         }


### PR DESCRIPTION
* Add `cmp` alu op for thumb
* Fix `tst` alu op for thumb (we were not reading the register value)
* Add a new unused region and a new interrupt register