### PR TITLE
`PSR`: Wrong LE conditional check

### DIFF
--- a/emu/src/cpu/psr.rs
+++ b/emu/src/cpu/psr.rs
@@ -24,7 +24,7 @@ impl Psr {
             GE => self.sign_flag() == self.overflow_flag(), // Greater or equal (N=V)
             LT => self.sign_flag() != self.overflow_flag(), // Less than (N<>V)
             GT => !self.zero_flag() && (self.sign_flag() == self.overflow_flag()), // Greater than (Z=0 and N=V)
-            LE => self.zero_flag() && (self.sign_flag() != self.overflow_flag()), // Less or equal (Z=1 or N<>V)
+            LE => self.zero_flag() || (self.sign_flag() != self.overflow_flag()), // Less or equal (Z=1 or N<>V)
             AL => true,  // Always (the "AL" suffix can be omitted)
             NV => false, // Never (ARMv1, v2 only) (Reserved ARMv3 and up)
         }


### PR DESCRIPTION
Probably a typo here (`&&` is used instead of `||`) as the comment next to this statement also suggest using an `or`. 
Docs [here](https://rust-console.github.io/gbatek-gbaonly/#saved-program-status-registers-spsr_mode) just for reference.

Side note: we should implement some tests accounting for instructions with conditional execution, this way we can spot these little quirks more efficiently.