### PR TITLE
CPU: Add program_counter to disassembler

### DIFF
--- a/emu/src/cpu/arm7tdmi.rs
+++ b/emu/src/cpu/arm7tdmi.rs
@@ -192,9 +192,13 @@ impl Arm7tdmi {
     }
 
     pub fn execute_thumb(&mut self, op_code: ThumbModeOpcode) {
-        self.disassembler_buffer
-            .push(op_code.instruction.disassembler());
-
+        let decimal_value = self.registers.program_counter();
+        let padded_hex_value = format!("{:#04X}", decimal_value);
+        self.disassembler_buffer.push(format!(
+            "{}: {}",
+            padded_hex_value,
+            op_code.instruction.disassembler()
+        ));
         use ThumbModeInstruction::*;
         let bytes_to_advance: Option<u32> = match op_code.instruction {
             MoveShiftedRegister {

--- a/emu/src/cpu/arm7tdmi.rs
+++ b/emu/src/cpu/arm7tdmi.rs
@@ -91,8 +91,13 @@ impl Arm7tdmi {
         let bytes_to_advance = if !self.cpsr.can_execute(op_code.condition) {
             Some(SIZE_OF_ARM_INSTRUCTION)
         } else {
-            self.disassembler_buffer
-                .push(op_code.instruction.disassembler());
+            let decimal_value = self.registers.program_counter();
+            let padded_hex_value = format!("{:#04X}", decimal_value);
+            self.disassembler_buffer.push(format!(
+                "{}: {}",
+                padded_hex_value,
+                op_code.instruction.disassembler()
+            ));
             match op_code.instruction {
                 DataProcessing {
                     condition: _,


### PR DESCRIPTION
Added the Program Counter (`R15`) to the `disassembler` window to help with debugging.

There is an error where the Program Counter disappears after so many steps ...