### PR TITLE
Arm: Implement mul opcodes (halfwords and non-halfwords)

### DIFF
--- a/emu/src/cpu/arm/mode.rs
+++ b/emu/src/cpu/arm/mode.rs
@@ -41,6 +41,12 @@ impl std::fmt::Display for ArmModeOpcode {
             ArmModeInstruction::DataProcessing { .. } => {
                 "FMT: |_Cond__|0_0|I|_code__|S|__Rn___|__Rd___|_______operand2________|"
             }
+            ArmModeInstruction::Multiply { .. } => {
+                "FMT: |_Cond__|0_0_0|__code__|S|_Rd__|_Rn__|_Rs__|1_0_0_1|__Rm___|"
+            }
+            ArmModeInstruction::MultiplyLong { .. } => {
+                "FMT: |_Cond__|0_0_0|__code__|S|_RdHi_|_RdLo_|_Rs__|1_0_0_1|_Rm__|"
+            }
             ArmModeInstruction::PSRTransfer {
                 condition: _,
                 psr_kind: _,
@@ -56,8 +62,6 @@ impl std::fmt::Display for ArmModeOpcode {
                     "FMT: |_Cond__|0_0|I|1_0|P|1_0_1_0_0_0_1_1_1_1|_Operand____|"
                 }
             },
-            ArmModeInstruction::Multiply => "FMT: |_Cond__|",
-            ArmModeInstruction::MultiplyLong => "FMT: |_Cond__|",
             ArmModeInstruction::SingleDataSwap => "FMT: |_Cond__|",
             ArmModeInstruction::BranchAndExchange { .. } => {
                 "FMT: |_Cond__|0_0_0_1|0_0_1_0|1_1_1_1|1_1_1_1|1_1_1_1|0_0_0_1|__Rn___|"

--- a/emu/src/cpu/arm7tdmi.rs
+++ b/emu/src/cpu/arm7tdmi.rs
@@ -129,8 +129,38 @@ impl Arm7tdmi {
                 psr_kind,
                 kind,
             } => self.psr_transfer(kind, psr_kind),
-            ArmModeInstruction::Multiply => todo!(),
-            ArmModeInstruction::MultiplyLong => todo!(),
+            ArmModeInstruction::Multiply {
+                variant,
+                should_set_codes,
+                rd_destination_register,
+                rn_accumulate_register,
+                rm_operand_register,
+                rs_operand_register,
+                ..
+            } => self.multiply(
+                variant,
+                should_set_codes,
+                rd_destination_register,
+                rn_accumulate_register,
+                rm_operand_register,
+                rs_operand_register,
+            ),
+            ArmModeInstruction::MultiplyLong {
+                variant,
+                should_set_codes,
+                rdhi_destination_register,
+                rdlo_destination_register,
+                rm_operand_register,
+                rs_operand_register,
+                ..
+            } => self.multiply_long(
+                variant,
+                should_set_codes,
+                rdhi_destination_register,
+                rdlo_destination_register,
+                rm_operand_register,
+                rs_operand_register,
+            ),
             ArmModeInstruction::SingleDataSwap => todo!(),
             ArmModeInstruction::BranchAndExchange {
                 condition: _,

--- a/emu/src/cpu/thumb/operations.rs
+++ b/emu/src/cpu/thumb/operations.rs
@@ -132,7 +132,7 @@ impl Arm7tdmi {
                 rs,
                 true,
             ),
-            ThumbModeAluInstruction::Mul => self.mul(
+            ThumbModeAluInstruction::Mul => self.thumb_mul(
                 rd.into(),
                 rs,
                 self.registers.register_at(rd.try_into().unwrap()),
@@ -534,6 +534,14 @@ impl Arm7tdmi {
             self.registers
                 .set_register_at(REG_LR, pc.wrapping_add(offset));
         }
+    }
+
+    pub fn thumb_mul(&mut self, reg_result: usize, op1: u32, op2: u32) {
+        let result = op1 as u64 * op2 as u64;
+
+        self.registers.set_register_at(reg_result, result as u32);
+        self.cpsr.set_zero_flag(result == 0);
+        self.cpsr.set_sign_flag(result.get_bit(31));
     }
 }
 


### PR DESCRIPTION
This PR brings the implementation of the various opcodes for multiplications in arm-mode, I decided to keep the already present `ArmModeInstruction::Multiply` type and extending it a little with a `ArmModeMultiplyKind` to allow for a basic way of differentiating the opcodes.

Overflows are checked using `u64|u32::overflowing_mul(op1, op2)` which conveniently returns a tuple containing the mul result and whether an overflow occurred. I chose this way as it clearly shows the intent of what's happening there, perhaps we could only use such function when the `S` flag is set, otherwise there's really no point in using that. (It might bring extra overhead for no reason, but you guys tell me if that's any good to keep it like so).

Other than that, I don't really have anything important here to address. The opcodes are quite similar to each other, and it's not guaranteed we're gonna need them all, but still I brought them as it required little effort to do so.

As for the testing side I tried to test the most common case for each one, some need to check for condition flags, some don't and so on...

Looking forward to improve this as much as we can! :v: 