### PR TITLE
ARM: Extract `PSRTransfer` instruction from `DataProcessing`

### DIFF
--- a/emu/src/cpu/arm/mode.rs
+++ b/emu/src/cpu/arm/mode.rs
@@ -41,6 +41,21 @@ impl std::fmt::Display for ArmModeOpcode {
             ArmModeInstruction::DataProcessing { .. } => {
                 "FMT: |_Cond__|0_0|I|_code__|S|__Rn___|__Rd___|_______operand2________|"
             }
+            ArmModeInstruction::PSRTransfer {
+                condition: _,
+                psr_kind: _,
+                kind,
+            } => match kind {
+                crate::cpu::arm::alu_instruction::PsrOpKind::Mrs { .. } => {
+                    "FMT: |_Cond__|0_0_0_1_0|P|0_0_1_1_1_1|_Rd__|0_0_0_0_0_0_0_0_0_0_0_0_0|"
+                }
+                crate::cpu::arm::alu_instruction::PsrOpKind::Msr { .. } => {
+                    "FMT: |_Cond__|0_0_0_1_0|P|1_0_1_0_0_1_1_1_1_1_0_0_0_0_0_0_0_0|__Rm___|"
+                }
+                crate::cpu::arm::alu_instruction::PsrOpKind::MsrFlg { .. } => {
+                    "FMT: |_Cond__|0_0|I|1_0|P|1_0_1_0_0_0_1_1_1_1|_Operand____|"
+                }
+            },
             ArmModeInstruction::Multiply => "FMT: |_Cond__|",
             ArmModeInstruction::MultiplyLong => "FMT: |_Cond__|",
             ArmModeInstruction::SingleDataSwap => "FMT: |_Cond__|",

--- a/emu/src/cpu/arm7tdmi.rs
+++ b/emu/src/cpu/arm7tdmi.rs
@@ -344,17 +344,6 @@ impl Arm7tdmi {
         }
     }
 
-    pub fn get_spsr(&self) -> Psr {
-        match self.cpsr.mode() {
-            Mode::User | Mode::System => panic!("Trying to access a SPSR in either User or System state which do not have banked SPSR."),
-            Mode::Fiq => self.register_bank.spsr_fiq,
-            Mode::Irq => self.register_bank.spsr_irq,
-            Mode::Abort => self.register_bank.spsr_abt,
-            Mode::Supervisor => self.register_bank.spsr_svc,
-            Mode::Undefined => self.register_bank.spsr_und
-        }
-    }
-
     pub fn swap_mode(&mut self, new_mode: Mode) {
         if self.cpsr.mode() == new_mode {
             return;

--- a/emu/src/cpu/arm7tdmi.rs
+++ b/emu/src/cpu/arm7tdmi.rs
@@ -124,6 +124,11 @@ impl Arm7tdmi {
                 rn,
                 destination,
             ),
+            ArmModeInstruction::PSRTransfer {
+                condition: _,
+                psr_kind,
+                kind,
+            } => self.psr_transfer(kind, psr_kind),
             ArmModeInstruction::Multiply => todo!(),
             ArmModeInstruction::MultiplyLong => todo!(),
             ArmModeInstruction::SingleDataSwap => todo!(),


### PR DESCRIPTION
These two type of instructions do very different
things even if they're under the same opcode
in the datasheet.
Splitting them makes also easier to
manage disassembly for PSR.