### PR TITLE
Avoid having `Arc<Mutex<Bus>>` inside `Arm7tdmi`

### DIFF
--- a/emu/src/bus.rs
+++ b/emu/src/bus.rs
@@ -1,12 +1,10 @@
-use std::sync::{Arc, Mutex};
-
 use logger::log;
 
 use crate::memory::{internal_memory::InternalMemory, io_device::IoDevice};
 
 #[derive(Default)]
 pub struct Bus {
-    pub internal_memory: Arc<Mutex<InternalMemory>>,
+    pub internal_memory: InternalMemory,
     cycles_count: u128,
     last_used_address: usize,
 }
@@ -17,7 +15,7 @@ impl Bus {
             self.step();
         }
 
-        self.internal_memory.lock().unwrap().read_at(address)
+        self.internal_memory.read_at(address)
     }
 
     pub fn write_at(&mut self, address: usize, value: u8) {
@@ -25,10 +23,7 @@ impl Bus {
             self.step();
         }
 
-        self.internal_memory
-            .lock()
-            .unwrap()
-            .write_at(address, value);
+        self.internal_memory.write_at(address, value);
     }
 
     fn step(&mut self) {
@@ -40,13 +35,16 @@ impl Bus {
         log(format!("CPU Cycles: {}", self.cycles_count));
 
         // Step ppu, dma, interrupts, timers, etc...
-        let mut mem = self.internal_memory.lock().unwrap();
-
-        let val = *mem.interrupts.interrupt_request.back().unwrap();
-        mem.interrupts.interrupt_request.push(val);
+        let val = *self
+            .internal_memory
+            .interrupts
+            .interrupt_request
+            .back()
+            .unwrap();
+        self.internal_memory.interrupts.interrupt_request.push(val);
     }
 
-    pub fn with_memory(memory: Arc<Mutex<InternalMemory>>) -> Self {
+    pub fn with_memory(memory: InternalMemory) -> Self {
         Self {
             internal_memory: memory,
             ..Default::default()
@@ -71,7 +69,7 @@ impl Bus {
 
         self.last_used_address = address;
 
-        self.internal_memory.lock().unwrap().read_word(address)
+        self.internal_memory.read_word(address)
     }
 
     pub fn write_word(&mut self, address: usize, value: u32) {
@@ -81,10 +79,7 @@ impl Bus {
 
         self.last_used_address = address;
 
-        self.internal_memory
-            .lock()
-            .unwrap()
-            .write_word(address, value);
+        self.internal_memory.write_word(address, value);
     }
 
     pub fn read_half_word(&mut self, address: usize) -> u16 {
@@ -92,7 +87,7 @@ impl Bus {
             self.step();
         }
 
-        self.internal_memory.lock().unwrap().read_half_word(address)
+        self.internal_memory.read_half_word(address)
     }
 
     pub fn write_half_word(&mut self, address: usize, value: u16) {
@@ -100,9 +95,6 @@ impl Bus {
             self.step();
         }
 
-        self.internal_memory
-            .lock()
-            .unwrap()
-            .write_half_word(address, value);
+        self.internal_memory.write_half_word(address, value);
     }
 }

--- a/emu/src/memory/interrupts.rs
+++ b/emu/src/memory/interrupts.rs
@@ -12,7 +12,7 @@ use super::io_device::IoDevice;
 
 pub struct Interrupts {
     /// 0x04000200  2    R/W  IE        Interrupt Enable Register
-    interrupt_enable: IORegister,
+    pub interrupt_enable: IORegister,
 
     /// 0x04000202  2    R/W  IF        Interrupt Request Flags / IRQ Acknowledge
     // It is a ring buffer since when we write to this register, the value will reach the CPU
@@ -26,7 +26,7 @@ pub struct Interrupts {
     wait_state: IORegister,
 
     /// Interrupt Master Enable Register
-    ime: IORegister,
+    pub ime: IORegister,
 
     //   400020Ah       -    -         Not used
     /// Post boot flag.

--- a/ui/src/cpu_handler.rs
+++ b/ui/src/cpu_handler.rs
@@ -70,7 +70,14 @@ impl UiTool for CpuHandler {
                 self.thread_handle = Some(thread::spawn(move || {
                     while play_clone.load(std::sync::atomic::Ordering::Relaxed) {
                         if breakpoints_clone.lock().unwrap().contains(
-                            &(gba_clone.lock().unwrap().cpu.registers.program_counter() as u32),
+                            &(gba_clone
+                                .lock()
+                                .unwrap()
+                                .cpu
+                                .lock()
+                                .unwrap()
+                                .registers
+                                .program_counter() as u32),
                         ) {
                             play_clone.swap(false, std::sync::atomic::Ordering::Relaxed);
                             return;

--- a/ui/src/cpu_registers.rs
+++ b/ui/src/cpu_registers.rs
@@ -46,12 +46,15 @@ impl UiTool for CpuRegisters {
         ui.radio_value(&mut self.base_kind, BaseKind::Hex, "Hexadecimal");
         ui.add_space(8.0);
 
-        // If it's poisoned it means that the thread that executes instructions
-        // panicked, we still want access to registers to debug
-        let registers = self.gba.lock().map_or_else(
-            |poisoned| poisoned.into_inner().cpu.registers.to_vec(),
-            |gba| gba.cpu.registers.to_vec(),
-        );
+        let registers = self
+            .gba
+            .lock()
+            .unwrap()
+            .cpu
+            .lock()
+            .unwrap()
+            .registers
+            .to_vec();
 
         let mut index = 0;
 

--- a/ui/src/disassembler.rs
+++ b/ui/src/disassembler.rs
@@ -30,7 +30,15 @@ impl UiTool for Disassembler {
     }
 
     fn ui(&mut self, ui: &mut egui::Ui) {
-        let mut s = self.gba.lock().unwrap().cpu.disassembler_buffer.join("\n");
+        let mut s = self
+            .gba
+            .lock()
+            .unwrap()
+            .cpu
+            .lock()
+            .unwrap()
+            .disassembler_buffer
+            .join("\n");
 
         ScrollArea::vertical().stick_to_bottom(true).show(ui, |ui| {
             ui.add(


### PR DESCRIPTION
The main idea of this change is to avoid having `Arc<Mutex<Bus>>` inside `Arm7tdmi` and have just a `Bus` instead.
Having an ArcMutex it was causing me some issues while working on interrupts implementation. Plus it's always been something I was not 100% sure about. I changed the `Gba` logic to hold only a reference to the cpu instead of both cpu and bus.