### PR TITLE
Move `Lcd` out of `InternalMemory`

### DIFF
--- a/emu/src/bus.rs
+++ b/emu/src/bus.rs
@@ -1,12 +1,20 @@
+use std::collections::HashMap;
+
 use logger::log;
 
+use crate::bitwise::Bits;
+use crate::cpu::hardware::lcd::Lcd;
+use crate::cpu::hardware::HardwareComponent;
 use crate::memory::{internal_memory::InternalMemory, io_device::IoDevice};
+use crate::cpu::hardware::lcd::Lcd;
 
 #[derive(Default)]
 pub struct Bus {
     pub internal_memory: InternalMemory,
+    pub lcd: Lcd,
     cycles_count: u128,
     last_used_address: usize,
+    unused_region: HashMap<usize, u8>,
 }
 
 impl Bus {

--- a/emu/src/bus.rs
+++ b/emu/src/bus.rs
@@ -6,7 +6,6 @@ use crate::bitwise::Bits;
 use crate::cpu::hardware::lcd::Lcd;
 use crate::cpu::hardware::HardwareComponent;
 use crate::memory::{internal_memory::InternalMemory, io_device::IoDevice};
-use crate::cpu::hardware::lcd::Lcd;
 
 #[derive(Default)]
 pub struct Bus {
@@ -18,20 +17,173 @@ pub struct Bus {
 }
 
 impl Bus {
-    pub fn read_at(&mut self, address: usize) -> u8 {
-        for _ in 0..self.get_wait_cycles(address) {
-            self.step();
+    fn read_lcd_raw(&self, address: usize) -> u8 {
+        match address {
+            0x04000000 => self.lcd.dispcnt.get_byte(0),
+            0x04000001 => self.lcd.dispcnt.get_byte(1),
+            0x04000002 => self.lcd.green_swap.get_byte(0),
+            0x04000003 => self.lcd.green_swap.get_byte(1),
+            0x04000004 => self.lcd.dispstat.get_byte(0),
+            0x04000005 => self.lcd.dispstat.get_byte(1),
+            0x04000006 => self.lcd.vcount.get_byte(0),
+            0x04000007 => self.lcd.vcount.get_byte(1),
+            0x04000008 => self.lcd.bg0cnt.get_byte(0),
+            0x04000009 => self.lcd.bg0cnt.get_byte(1),
+            0x0400000A => self.lcd.bg1cnt.get_byte(0),
+            0x0400000B => self.lcd.bg1cnt.get_byte(1),
+            0x0400000C => self.lcd.bg2cnt.get_byte(0),
+            0x0400000D => self.lcd.bg2cnt.get_byte(1),
+            0x0400000E => self.lcd.bg3cnt.get_byte(0),
+            0x0400000F => self.lcd.bg3cnt.get_byte(1),
+            0x04000010..=0x04000047 => panic!("Reading a write-only LCD I/O register"),
+            0x04000048 => self.lcd.winin.get_byte(0),
+            0x04000049 => self.lcd.winin.get_byte(1),
+            0x0400004A => self.lcd.winout.get_byte(0),
+            0x0400004B => self.lcd.winout.get_byte(1),
+            0x0400004C => self.lcd.mosaic.get_byte(0),
+            0x0400004D => self.lcd.mosaic.get_byte(1),
+            0x04000050 => self.lcd.bldcnt.get_byte(0),
+            0x04000051 => self.lcd.bldcnt.get_byte(1),
+            0x04000052 => self.lcd.bldalpha.get_byte(0),
+            0x04000053 => self.lcd.bldalpha.get_byte(1),
+            0x04000054..=0x04000055 => panic!("Reading a write-only LCD I/O register"),
+            0x0400004E..=0x0400004F | 0x04000056..=0x0400005F => {
+                log("read on unused memory");
+                self.unused_region.get(&address).map_or(0, |v| *v)
+            }
+            _ => panic!("LCD read address is out of bound"),
         }
-
-        self.internal_memory.read_at(address)
     }
 
-    pub fn write_at(&mut self, address: usize, value: u8) {
+    fn write_lcd_raw(&mut self, address: usize, value: u8) {
+        match address {
+            0x04000000 => self.lcd.dispcnt.set_byte(0, value),
+            0x04000001 => self.lcd.dispcnt.set_byte(1, value),
+            0x04000002 => self.lcd.green_swap.set_byte(0, value),
+            0x04000003 => self.lcd.green_swap.set_byte(1, value),
+            0x04000004 => self.lcd.dispstat.set_byte(0, value),
+            0x04000005 => self.lcd.dispstat.set_byte(1, value),
+            0x04000008 => self.lcd.bg0cnt.set_byte(0, value),
+            0x04000006 => self.lcd.vcount.set_byte(0, value),
+            0x04000007 => self.lcd.vcount.set_byte(1, value),
+            0x04000009 => self.lcd.bg0cnt.set_byte(1, value),
+            0x0400000A => self.lcd.bg1cnt.set_byte(0, value),
+            0x0400000B => self.lcd.bg1cnt.set_byte(1, value),
+            0x0400000C => self.lcd.bg2cnt.set_byte(0, value),
+            0x0400000D => self.lcd.bg2cnt.set_byte(1, value),
+            0x0400000E => self.lcd.bg3cnt.set_byte(0, value),
+            0x0400000F => self.lcd.bg3cnt.set_byte(1, value),
+            0x04000010 => self.lcd.bg0hofs.set_byte(0, value),
+            0x04000011 => self.lcd.bg0hofs.set_byte(1, value),
+            0x04000012 => self.lcd.bg0vofs.set_byte(0, value),
+            0x04000013 => self.lcd.bg0vofs.set_byte(1, value),
+            0x04000014 => self.lcd.bg1hofs.set_byte(0, value),
+            0x04000015 => self.lcd.bg1hofs.set_byte(1, value),
+            0x04000016 => self.lcd.bg1vofs.set_byte(0, value),
+            0x04000017 => self.lcd.bg1vofs.set_byte(1, value),
+            0x04000018 => self.lcd.bg2hofs.set_byte(0, value),
+            0x04000019 => self.lcd.bg2hofs.set_byte(1, value),
+            0x0400001A => self.lcd.bg2vofs.set_byte(0, value),
+            0x0400001B => self.lcd.bg2vofs.set_byte(1, value),
+            0x0400001C => self.lcd.bg3hofs.set_byte(0, value),
+            0x0400001D => self.lcd.bg3hofs.set_byte(1, value),
+            0x0400001E => self.lcd.bg3vofs.set_byte(0, value),
+            0x0400001F => self.lcd.bg3vofs.set_byte(1, value),
+            0x04000020 => self.lcd.bg2pa.set_byte(0, value),
+            0x04000021 => self.lcd.bg2pa.set_byte(1, value),
+            0x04000022 => self.lcd.bg2pb.set_byte(0, value),
+            0x04000023 => self.lcd.bg2pb.set_byte(1, value),
+            0x04000024 => self.lcd.bg2pc.set_byte(0, value),
+            0x04000025 => self.lcd.bg2pc.set_byte(1, value),
+            0x04000026 => self.lcd.bg2pd.set_byte(0, value),
+            0x04000027 => self.lcd.bg2pd.set_byte(1, value),
+            0x04000028 => self.lcd.bg2x.set_byte(0, value),
+            0x04000029 => self.lcd.bg2x.set_byte(1, value),
+            0x0400002A => self.lcd.bg2x.set_byte(2, value),
+            0x0400002B => self.lcd.bg2x.set_byte(3, value),
+            0x0400002C => self.lcd.bg2y.set_byte(0, value),
+            0x0400002D => self.lcd.bg2y.set_byte(1, value),
+            0x0400002E => self.lcd.bg2y.set_byte(2, value),
+            0x0400002F => self.lcd.bg2y.set_byte(3, value),
+            0x04000030 => self.lcd.bg3pa.set_byte(0, value),
+            0x04000031 => self.lcd.bg3pa.set_byte(1, value),
+            0x04000032 => self.lcd.bg3pb.set_byte(0, value),
+            0x04000033 => self.lcd.bg3pb.set_byte(1, value),
+            0x04000034 => self.lcd.bg3pc.set_byte(0, value),
+            0x04000035 => self.lcd.bg3pc.set_byte(1, value),
+            0x04000036 => self.lcd.bg3pd.set_byte(0, value),
+            0x04000037 => self.lcd.bg3pd.set_byte(1, value),
+            0x04000038 => self.lcd.bg3x.set_byte(0, value),
+            0x04000039 => self.lcd.bg3x.set_byte(1, value),
+            0x0400003A => self.lcd.bg3x.set_byte(2, value),
+            0x0400003B => self.lcd.bg3x.set_byte(3, value),
+            0x0400003C => self.lcd.bg3y.set_byte(0, value),
+            0x0400003D => self.lcd.bg3y.set_byte(1, value),
+            0x0400003E => self.lcd.bg3y.set_byte(2, value),
+            0x0400003F => self.lcd.bg3y.set_byte(3, value),
+            0x04000040 => self.lcd.win0h.set_byte(0, value),
+            0x04000041 => self.lcd.win0h.set_byte(1, value),
+            0x04000042 => self.lcd.win1h.set_byte(0, value),
+            0x04000043 => self.lcd.win1h.set_byte(1, value),
+            0x04000044 => self.lcd.win0v.set_byte(0, value),
+            0x04000045 => self.lcd.win0v.set_byte(1, value),
+            0x04000046 => self.lcd.win1v.set_byte(0, value),
+            0x04000047 => self.lcd.win1v.set_byte(1, value),
+            0x04000048 => self.lcd.winin.set_byte(0, value),
+            0x04000049 => self.lcd.winin.set_byte(1, value),
+            0x0400004A => self.lcd.winout.set_byte(0, value),
+            0x0400004B => self.lcd.winout.set_byte(1, value),
+            0x0400004C => self.lcd.mosaic.set_byte(0, value),
+            0x0400004D => self.lcd.mosaic.set_byte(1, value),
+            // 0x0400004E, 0x0400004F are not used
+            0x04000050 => self.lcd.bldcnt.set_byte(0, value),
+            0x04000051 => self.lcd.bldcnt.set_byte(1, value),
+            0x04000052 => self.lcd.bldalpha.set_byte(0, value),
+            0x04000053 => self.lcd.bldalpha.set_byte(1, value),
+            0x04000054 => self.lcd.bldy.set_byte(0, value),
+            0x04000055 => self.lcd.bldy.set_byte(1, value),
+            0x0400004E..=0x0400004F | 0x04000056..=0x0400005F => {
+                log("write on unused memory");
+                self.unused_region.insert(address, value);
+            }
+            _ => panic!("LCD write address is out of bound"),
+        }
+    }
+
+    fn read_raw(&self, address: usize) -> u8 {
+        match address {
+            0x4000000..=0x4000057 => self.read_lcd_raw(address),
+            // TODO: change also other devices similar to how LCD is handled
+            _ => self.internal_memory.read_at(address),
+        }
+    }
+
+    fn write_raw(&mut self, address: usize, value: u8) {
+        match address {
+            0x4000000..=0x4000057 => self.write_lcd_raw(address, value),
+            // TODO: read read_raw
+            _ => self.internal_memory.write_at(address, value),
+        }
+    }
+
+    pub fn read_byte(&mut self, address: usize) -> u8 {
         for _ in 0..self.get_wait_cycles(address) {
             self.step();
         }
 
-        self.internal_memory.write_at(address, value);
+        self.last_used_address = address;
+
+        self.read_raw(address)
+    }
+
+    pub fn write_byte(&mut self, address: usize, value: u8) {
+        for _ in 0..self.get_wait_cycles(address) {
+            self.step();
+        }
+
+        self.last_used_address = address;
+
+        self.write_raw(address, value);
     }
 
     fn step(&mut self) {
@@ -59,7 +211,10 @@ impl Bus {
             .unwrap();
         self.internal_memory.interrupts.interrupt_request.push(val);
 
-        self.internal_memory.step(); // FIXME: We can do better than this.
+        // A pixel takes 4 cycles to get drawn
+        if self.cycles_count % 4 == 0 {
+            self.lcd.step();
+        }
     }
 
     pub fn with_memory(memory: InternalMemory) -> Self {
@@ -81,38 +236,122 @@ impl Bus {
     }
 
     pub fn read_word(&mut self, address: usize) -> u32 {
+        // TODO: here we have to see how many times to wait for the waitcycles
+        // It depends on the bus width of the memory region
+        // Right now we're assuming that every region has a bus width of 32 bits
+        // So we wait only once to read a word.
+        // In reality for example WRAM has a bus width of 16 bits so we would
+        // have to repeat this cycle 2 times (to emulate the fact that we will access the memory
+        // two times)
         for _ in 0..self.get_wait_cycles(address) {
             self.step();
         }
 
         self.last_used_address = address;
 
-        self.internal_memory.read_word(address)
+        if address & 3 != 0 {
+            log("warning, read_word has address not word aligned");
+        }
+
+        let part_0: u32 = self.read_raw(address).try_into().unwrap();
+        let part_1: u32 = self.read_raw(address + 1).try_into().unwrap();
+        let part_2: u32 = self.read_raw(address + 2).try_into().unwrap();
+        let part_3: u32 = self.read_raw(address + 3).try_into().unwrap();
+
+        part_3 << 24_u32 | part_2 << 16_u32 | part_1 << 8_u32 | part_0
     }
 
     pub fn write_word(&mut self, address: usize, value: u32) {
+        // TODO: Look at read_word
         for _ in 0..self.get_wait_cycles(address) {
             self.step();
         }
 
         self.last_used_address = address;
 
-        self.internal_memory.write_word(address, value);
+        if address & 3 != 0 {
+            log("warning, write_word has address not word aligned");
+        }
+
+        let part_0: u8 = value.get_bits(0..=7).try_into().unwrap();
+        let part_1: u8 = value.get_bits(8..=15).try_into().unwrap();
+        let part_2: u8 = value.get_bits(16..=23).try_into().unwrap();
+        let part_3: u8 = value.get_bits(24..=31).try_into().unwrap();
+
+        self.write_raw(address, part_0);
+        self.write_raw(address + 1, part_1);
+        self.write_raw(address + 2, part_2);
+        self.write_raw(address + 3, part_3);
     }
 
     pub fn read_half_word(&mut self, address: usize) -> u16 {
+        // TODO: Look at read_word
         for _ in 0..self.get_wait_cycles(address) {
             self.step();
         }
 
-        self.internal_memory.read_half_word(address)
+        self.last_used_address = address;
+
+        if address & 1 != 0 {
+            log("warning, read_half_word has address not half-word aligned");
+        }
+
+        let part_0: u16 = self.read_raw(address).try_into().unwrap();
+        let part_1: u16 = self.read_raw(address + 1).try_into().unwrap();
+
+        part_1 << 8 | part_0
     }
 
     pub fn write_half_word(&mut self, address: usize, value: u16) {
+        // TODO: Look at read_word
         for _ in 0..self.get_wait_cycles(address) {
             self.step();
         }
 
-        self.internal_memory.write_half_word(address, value);
+        self.last_used_address = address;
+
+        if address & 1 != 0 {
+            log("warning, write_half_word has address not half-word aligned");
+        }
+
+        let part_0: u8 = value.get_bits(0..=7).try_into().unwrap();
+        let part_1: u8 = value.get_bits(8..=15).try_into().unwrap();
+
+        self.write_raw(address, part_0);
+        self.write_raw(address + 1, part_1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::bus::Bus;
+
+    #[test]
+    fn test_write_lcd_reg() {
+        let mut bus = Bus::default();
+        let address = 0x04000048; // WININ lower byte
+
+        bus.write_raw(address, 10);
+
+        assert_eq!(bus.lcd.winin, 10);
+
+        let address = 0x04000049; // WININ higher byte
+
+        bus.write_raw(address, 5);
+        assert_eq!(bus.lcd.winin, (5 << 8) | 10);
+    }
+
+    #[test]
+    fn test_read_lcd_reg() {
+        let mut bus = Bus::default();
+        let address = 0x04000048; // WININ lower byte
+
+        bus.lcd.winin = (5 << 8) | 10;
+
+        assert_eq!(bus.read_raw(address), 10);
+
+        let address = 0x04000049; // WININ higher byte
+
+        assert_eq!(bus.read_raw(address), 5);
     }
 }

--- a/emu/src/cpu/arm/operations.rs
+++ b/emu/src/cpu/arm/operations.rs
@@ -579,7 +579,7 @@ impl Arm7tdmi {
                         .set_register_at(source_destination_register as usize, v.into());
                 }
                 HalfwordTransferKind::SignedByte => {
-                    let v = self.bus.read_at(address) as u32;
+                    let v = self.bus.read_byte(address) as u32;
                     self.registers
                         .set_register_at(source_destination_register as usize, v.sign_extended(8));
                 }
@@ -656,7 +656,7 @@ impl Arm7tdmi {
         match kind {
             SingleDataTransferKind::Ldr => match quantity {
                 ReadWriteKind::Byte => {
-                    let value = self.bus.read_at(address) as u32;
+                    let value = self.bus.read_byte(address) as u32;
                     self.registers
                         .set_register_at(rd.try_into().unwrap(), value)
                 }
@@ -674,7 +674,7 @@ impl Arm7tdmi {
                         v += 4;
                     }
 
-                    self.bus.write_at(address, v as u8)
+                    self.bus.write_byte(address, v as u8)
                 }
                 ReadWriteKind::Word => {
                     let mut v = self.registers.register_at(rd.try_into().unwrap());
@@ -684,10 +684,7 @@ impl Arm7tdmi {
                         v += 4;
                     }
 
-                    self.bus.write_at(address, v.get_bits(0..=7) as u8);
-                    self.bus.write_at(address + 1, v.get_bits(8..=15) as u8);
-                    self.bus.write_at(address + 2, v.get_bits(16..=23) as u8);
-                    self.bus.write_at(address + 3, v.get_bits(24..=31) as u8);
+                    self.bus.write_word(address, v);
                 }
             },
             _ => todo!("implement single data transfer operation"),
@@ -2416,7 +2413,7 @@ mod tests {
             cpu.registers.set_program_counter(0x03000050);
 
             // simulate mem already contains something.
-            cpu.bus.write_at(0x03000068, 99);
+            cpu.bus.write_byte(0x03000068, 99);
 
             cpu.execute_arm(op_code);
             assert_eq!(cpu.registers.register_at(13), 99);
@@ -2540,10 +2537,7 @@ mod tests {
 
         // simulate mem already contains something.
         // in u32 this is 16843009 00000001_00000001_00000001_00000001.
-        cpu.bus.write_at(0x28, 1);
-        cpu.bus.write_at(0x28 + 1, 1);
-        cpu.bus.write_at(0x28 + 2, 1);
-        cpu.bus.write_at(0x28 + 3, 1);
+        cpu.bus.write_word(0x28, 0x01010101);
         cpu.execute_arm(op_code);
         assert_eq!(cpu.registers.register_at(13), 16843009);
         assert_eq!(cpu.registers.program_counter(), 0);

--- a/emu/src/cpu/arm7tdmi.rs
+++ b/emu/src/cpu/arm7tdmi.rs
@@ -608,9 +608,9 @@ mod tests {
             let op_code: ArmModeOpcode = Arm7tdmi::decode(op_code);
 
             cpu.registers.set_register_at(13, 0x1000);
-            cpu.bus.write_at(0x1000, 1);
-            cpu.bus.write_at(0x1004, 5);
-            cpu.bus.write_at(0x1008, 7);
+            cpu.bus.write_byte(0x1000, 1);
+            cpu.bus.write_byte(0x1004, 5);
+            cpu.bus.write_byte(0x1008, 7);
             cpu.execute_arm(op_code);
 
             assert_eq!(cpu.registers.register_at(1), 1);
@@ -625,9 +625,9 @@ mod tests {
             let op_code: ArmModeOpcode = Arm7tdmi::decode(op_code);
 
             cpu.registers.set_register_at(13, 0x1000);
-            cpu.bus.write_at(0x1004, 1);
-            cpu.bus.write_at(0x1008, 5);
-            cpu.bus.write_at(0x100C, 7);
+            cpu.bus.write_byte(0x1004, 1);
+            cpu.bus.write_byte(0x1008, 5);
+            cpu.bus.write_byte(0x100C, 7);
             cpu.execute_arm(op_code);
 
             assert_eq!(cpu.registers.register_at(1), 1);
@@ -642,9 +642,9 @@ mod tests {
             let op_code: ArmModeOpcode = Arm7tdmi::decode(op_code);
 
             cpu.registers.set_register_at(13, 0x1000);
-            cpu.bus.write_at(0x1000, 7);
-            cpu.bus.write_at(0x0FFC, 5);
-            cpu.bus.write_at(0x0FF8, 1);
+            cpu.bus.write_byte(0x1000, 7);
+            cpu.bus.write_byte(0x0FFC, 5);
+            cpu.bus.write_byte(0x0FF8, 1);
             cpu.execute_arm(op_code);
 
             assert_eq!(cpu.registers.register_at(1), 1);
@@ -659,9 +659,9 @@ mod tests {
             let op_code: ArmModeOpcode = Arm7tdmi::decode(op_code);
 
             cpu.registers.set_register_at(13, 0x1000);
-            cpu.bus.write_at(0x0FFC, 7);
-            cpu.bus.write_at(0x0FF8, 5);
-            cpu.bus.write_at(0x0FF4, 1);
+            cpu.bus.write_byte(0x0FFC, 7);
+            cpu.bus.write_byte(0x0FF8, 5);
+            cpu.bus.write_byte(0x0FF4, 1);
             cpu.execute_arm(op_code);
 
             assert_eq!(cpu.registers.register_at(1), 1);
@@ -685,9 +685,9 @@ mod tests {
 
             let mut bus = cpu.bus;
 
-            assert_eq!(bus.read_at(0x1000), 1);
-            assert_eq!(bus.read_at(0x1004), 5);
-            assert_eq!(bus.read_at(0x1008), 7);
+            assert_eq!(bus.read_byte(0x1000), 1);
+            assert_eq!(bus.read_byte(0x1004), 5);
+            assert_eq!(bus.read_byte(0x1008), 7);
             assert_eq!(cpu.registers.register_at(13), 0x100C);
         }
         {
@@ -706,10 +706,10 @@ mod tests {
 
             let mut bus = cpu.bus;
 
-            assert_eq!(bus.read_at(0x1000), 0);
-            assert_eq!(bus.read_at(0x1004), 1);
-            assert_eq!(bus.read_at(0x1008), 5);
-            assert_eq!(bus.read_at(0x100C), 7);
+            assert_eq!(bus.read_byte(0x1000), 0);
+            assert_eq!(bus.read_byte(0x1004), 1);
+            assert_eq!(bus.read_byte(0x1008), 5);
+            assert_eq!(bus.read_byte(0x100C), 7);
             assert_eq!(cpu.registers.register_at(13), 0x100C);
         }
         {
@@ -728,9 +728,9 @@ mod tests {
 
             let mut bus = cpu.bus;
 
-            assert_eq!(bus.read_at(0x1000), 7);
-            assert_eq!(bus.read_at(0x0FFC), 5);
-            assert_eq!(bus.read_at(0x0FF8), 1);
+            assert_eq!(bus.read_byte(0x1000), 7);
+            assert_eq!(bus.read_byte(0x0FFC), 5);
+            assert_eq!(bus.read_byte(0x0FF8), 1);
             assert_eq!(cpu.registers.register_at(13), 0x0FF4);
         }
         {
@@ -750,11 +750,11 @@ mod tests {
 
             let mut bus = cpu.bus;
 
-            assert_eq!(bus.read_at(0x1000), 0);
-            assert_eq!(bus.read_at(0x0FFC), 15 + 4);
-            assert_eq!(bus.read_at(0x0FF8), 7);
-            assert_eq!(bus.read_at(0x0FF4), 5);
-            assert_eq!(bus.read_at(0x0FF0), 1);
+            assert_eq!(bus.read_byte(0x1000), 0);
+            assert_eq!(bus.read_byte(0x0FFC), 15 + 4);
+            assert_eq!(bus.read_byte(0x0FF8), 7);
+            assert_eq!(bus.read_byte(0x0FF4), 5);
+            assert_eq!(bus.read_byte(0x0FF0), 1);
             assert_eq!(cpu.registers.register_at(13), 0x0FF0);
         }
     }
@@ -786,11 +786,11 @@ mod tests {
 
             let mut bus = cpu.bus;
 
-            assert_eq!(bus.read_at(0), 1);
-            assert_eq!(bus.read_at(1), 1);
+            assert_eq!(bus.read_byte(0), 1);
+            assert_eq!(bus.read_byte(1), 1);
             // because we store halfword = 16bit
-            assert_eq!(bus.read_at(2), 0);
-            assert_eq!(bus.read_at(3), 0);
+            assert_eq!(bus.read_byte(2), 0);
+            assert_eq!(bus.read_byte(3), 0);
         }
         {
             // Immediate offset, pre-index, down, no wb, load, unsigned halfword
@@ -855,7 +855,7 @@ mod tests {
             let op_code: ArmModeOpcode = Arm7tdmi::decode(op_code);
 
             cpu.registers.set_register_at(0, 100);
-            cpu.bus.write_at(100, -5_i8 as u8);
+            cpu.bus.write_byte(100, -5_i8 as u8);
 
             cpu.execute_arm(op_code);
 
@@ -941,7 +941,7 @@ mod tests {
         let op_code: ThumbModeOpcode = Arm7tdmi::decode(op_code);
 
         cpu.registers.set_register_at(1, 10);
-        cpu.bus.write_at(352, 1);
+        cpu.bus.write_byte(352, 1);
         cpu.execute_thumb(op_code);
 
         assert_eq!(cpu.registers.register_at(1), 1);
@@ -975,10 +975,10 @@ mod tests {
 
             cpu.execute_thumb(op_code);
 
-            assert_eq!(cpu.bus.read_at(200), 0x1F);
-            assert_eq!(cpu.bus.read_at(201), 0);
-            assert_eq!(cpu.bus.read_at(202), 0);
-            assert_eq!(cpu.bus.read_at(203), 0);
+            assert_eq!(cpu.bus.read_byte(200), 0x1F);
+            assert_eq!(cpu.bus.read_byte(201), 0);
+            assert_eq!(cpu.bus.read_byte(202), 0);
+            assert_eq!(cpu.bus.read_byte(203), 0);
         }
         // Checks Load Word
         {
@@ -1059,7 +1059,7 @@ mod tests {
             cpu.execute_thumb(op_code);
 
             let mut bus = cpu.bus;
-            assert_eq!(bus.read_at(10), 0xFF);
+            assert_eq!(bus.read_byte(10), 0xFF);
         }
     }
 
@@ -1626,7 +1626,7 @@ mod tests {
                 prepare_fn: Box::new(|cpu| {
                     cpu.registers.set_register_at(0, 10);
                     cpu.registers.set_register_at(1, 100);
-                    cpu.bus.write_at(110, 0x80);
+                    cpu.bus.write_byte(110, 0x80);
                 }),
                 check_fn: Box::new(|cpu| {
                     assert_eq!(cpu.registers.register_at(2), 0xFFFF_FF80);

--- a/emu/src/cpu/hardware/lcd.rs
+++ b/emu/src/cpu/hardware/lcd.rs
@@ -1,0 +1,116 @@
+use crate::bitwise::Bits;
+
+use super::HardwareComponent;
+
+#[derive(Default)]
+pub struct Lcd {
+    /// LCD Control
+    pub dispcnt: u16,
+    /// Undocumented - Green Swap
+    pub green_swap: u16,
+    /// General LCD Status (STAT, LYC)
+    pub dispstat: u16,
+    /// Vertical Counter (LY)
+    pub vcount: u16,
+    /// BG0 Control
+    pub bg0cnt: u16,
+    /// BG1 Control
+    pub bg1cnt: u16,
+    /// BG2 Control
+    pub bg2cnt: u16,
+    /// BG3 Control
+    pub bg3cnt: u16,
+    /// BG0 X-Offset
+    pub bg0hofs: u16,
+    /// BG0 Y_Offset
+    pub bg0vofs: u16,
+    /// BG1 X-Offset
+    pub bg1hofs: u16,
+    /// BG1 Y_Offset
+    pub bg1vofs: u16,
+    /// BG2 X-Offset
+    pub bg2hofs: u16,
+    /// BG2 Y_Offset
+    pub bg2vofs: u16,
+    /// BG3 X-Offset
+    pub bg3hofs: u16,
+    /// BG3 Y_Offset
+    pub bg3vofs: u16,
+    /// BG2 Rotation/Scaling Parameter A (dx)
+    pub bg2pa: u16,
+    /// BG2 Rotation/Scaling Parameter B (dmx)
+    pub bg2pb: u16,
+    /// BG2 Rotation/Scaling Parameter C (dy)
+    pub bg2pc: u16,
+    /// BG2 Rotation/Scaling Parameter D (dmy)
+    pub bg2pd: u16,
+    /// BG2 Reference Point X-Coordinate
+    pub bg2x: u32,
+    /// BG2 Reference Point Y-Coordinate
+    pub bg2y: u32,
+    /// BG3 Rotation/Scaling Parameter A (dx)
+    pub bg3pa: u16,
+    /// BG3 Rotation/Scaling Parameter B (dmx)
+    pub bg3pb: u16,
+    /// BG3 Rotation/Scaling Parameter C (dy)
+    pub bg3pc: u16,
+    /// BG3 Rotation/Scaling Parameter D (dmy)
+    pub bg3pd: u16,
+    /// BG3 Reference Point X-Coordinate
+    pub bg3x: u32,
+    /// BG3 Reference Point Y-Coordinate
+    pub bg3y: u32,
+    /// Window 0 Horizontal Dimensions
+    pub win0h: u16,
+    /// Window 1 Horizontal Dimensions
+    pub win1h: u16,
+    /// Window 0 Vertical Dimensions
+    pub win0v: u16,
+    /// Window 1 Vertical Dimensions
+    pub win1v: u16,
+    /// Inside of Window 0 and 1
+    pub winin: u16,
+    /// Inside of OBJ Window & Outside of Windows
+    pub winout: u16,
+    /// Mosaic Size
+    pub mosaic: u16,
+    /// Color Special Effects Selection
+    pub bldcnt: u16,
+    /// Alpha Blending Coefficients
+    pub bldalpha: u16,
+    /// Brightness (Fade-In/Out) Coefficient
+    pub bldy: u16,
+
+    pixel_index: u32,
+}
+
+impl HardwareComponent for Lcd {
+    fn step(&mut self) {
+        // This will be much more complex obviously
+
+        // TODO: draw the pixel
+        self.pixel_index += 1;
+
+        if self.pixel_index == 308 {
+            // We finished to draw the scanline
+            self.pixel_index = 0;
+            self.vcount += 1;
+
+            // We finished to draw the screen
+            if self.vcount == 228 {
+                self.vcount = 0;
+            }
+        }
+    }
+
+    fn is_interrupt_pending(&self) -> bool {
+        false
+    }
+}
+
+impl Lcd {
+    /// Info about vram fields used to render display.
+    pub fn get_bg_mode(&self) -> u8 {
+        self.dispcnt.get_bits(0..=2).try_into().unwrap()
+    }
+}

--- a/emu/src/cpu/hardware/mod.rs
+++ b/emu/src/cpu/hardware/mod.rs
@@ -1,0 +1,8 @@
+pub mod lcd;
+
+pub trait HardwareComponent {
+    fn step(&mut self);
+
+    // not sure if it will be useful, let's see
+    fn is_interrupt_pending(&self) -> bool;
+}

--- a/emu/src/cpu/mod.rs
+++ b/emu/src/cpu/mod.rs
@@ -3,6 +3,7 @@ pub mod arm7tdmi;
 mod condition;
 mod cpu_modes;
 mod flags;
+pub mod hardware;
 mod psr;
 mod register_bank;
 mod registers;

--- a/emu/src/cpu/thumb/operations.rs
+++ b/emu/src/cpu/thumb/operations.rs
@@ -224,14 +224,14 @@ impl Arm7tdmi {
         match (load_store, byte_word) {
             (LoadStoreKind::Store, ReadWriteKind::Byte) => {
                 let rd = (self.registers.register_at(rd) & 0xFF) as u8;
-                self.bus.write_at(address, rd);
+                self.bus.write_byte(address, rd);
             }
             (LoadStoreKind::Store, ReadWriteKind::Word) => {
                 let rd = self.registers.register_at(rd);
                 self.bus.write_word(address, rd);
             }
             (LoadStoreKind::Load, ReadWriteKind::Byte) => {
-                let value = self.bus.read_at(address);
+                let value = self.bus.read_byte(address);
                 self.registers.set_register_at(rd, value as u32);
             }
             (LoadStoreKind::Load, ReadWriteKind::Word) => {
@@ -271,7 +271,7 @@ impl Arm7tdmi {
             }
             // Load sign-extended byte
             (true, false) => {
-                let mut value = self.bus.read_at(address) as u32;
+                let mut value = self.bus.read_byte(address) as u32;
                 value = value.sign_extended(8);
 
                 self.registers
@@ -311,14 +311,14 @@ impl Arm7tdmi {
             }
             (LoadStoreKind::Store, ReadWriteKind::Byte) => {
                 let v = self.registers.register_at(rd);
-                self.bus.write_at(address, v as u8)
+                self.bus.write_byte(address, v as u8)
             }
             (LoadStoreKind::Load, ReadWriteKind::Word) => {
                 let v = self.bus.read_word(address);
                 self.registers.set_register_at(rd, v);
             }
             (LoadStoreKind::Load, ReadWriteKind::Byte) => {
-                let v = self.bus.read_at(address);
+                let v = self.bus.read_byte(address);
                 self.registers.set_register_at(rd, v as u32);
             }
         }

--- a/emu/src/memory/mod.rs
+++ b/emu/src/memory/mod.rs
@@ -4,7 +4,6 @@ mod interrupts;
 pub mod io_device;
 mod io_registers;
 mod keypad;
-mod lcd_registers;
 mod serial_communication;
 mod sound;
 mod timer_registers;

--- a/emu/src/render/ppu.rs
+++ b/emu/src/render/ppu.rs
@@ -30,14 +30,7 @@ impl PixelProcessUnit {
     /// # Panics
     pub fn render(&self) {
         #[allow(unused_assignments)]
-        let mut bg_mode = self
-            .cpu
-            .lock()
-            .unwrap()
-            .bus
-            .internal_memory
-            .lcd_registers
-            .get_bg_mode();
+        let mut bg_mode = self.cpu.lock().unwrap().bus.lcd.get_bg_mode();
 
         // BG_MODE_3 forced for now.
         bg_mode = 3;


### PR DESCRIPTION
The idea of this PR is to propose a new way to manage memory and hardware components.
Before we had everything under `InternalMemory` but every field was just containing registers.
This is not suitable now that we approach implementing the LCD since it has also its login instead of just a bunch of registers.

Also, having everything under `InternalMemory` was not "semantically" correct in my opinion, hardware components are external components to the CPU.

If we agree with this type of refactoring, we would also get rid of the `IORegister` struct which is useless at this point. I added it many months ago to try to handle read/write access through it but then we saw that it was not possible.

To manage read/write access we could do something like this:

- If the register is R/W, just make the field `pub`
- If the register is R, keep the field private and write a getter for the field
- If the register is W, just make the field `pub`

I also changed a bit the read/write functions in `Bus`.
Now we have `write_raw` and `read_raw` that map every address to the correct component and we have wrappers like `read_word`, `write_word`, `read_half_word`, etc... that should calculate how many wait cycles the CPU has to be stopped (depending on wait cycles and bus width of the component).