### PR TITLE
Create `logger` and `disassembler` feature default disabled

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,16 +20,22 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  fmt:
+  lint:
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v3
+      - name: Setup just
+        uses: extractions/setup-just@v1
+
+      - uses: actions/checkout@v4
+
       - name: Check fmt
-        run: cargo fmt --all --check
+        run: cargo fmt -- --check
+
+      - name: Check clippy
+        run: just lint
 
   test:
-    needs: [fmt]
+    needs: [lint]
     strategy:
       fail-fast: false
       matrix:
@@ -37,23 +43,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Setup just
+        uses: extractions/setup-just@v1
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Test
-        run: cargo test --workspace
-
-  lint:
-    needs: [fmt, test]
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Lint
-        run: |
-          cargo clippy --workspace -- -D warnings     \
-          -W clippy::complexity                       \
-          -W clippy::correctness                      \
-          -W clippy::nursery                          \
-          -W clippy::perf                             \
-          -W clippy::style                            \
-          -W clippy::suspicious
+        run: just test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,4 @@ pretty_assertions = "1.3.0"
 rand = "0.8.5"
 
 [features]
-debug = [
-    "ui/debug"
-]
-
-test_bitmap_3 = ["ui/test_bitmap_3"]
-test_bitmap_5 = ["ui/test_bitmap_5"]
+logger = ["logger/logger", "emu/logger"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,4 @@ rand = "0.8.5"
 
 [features]
 logger = ["logger/logger", "emu/logger"]
+disassembler = ["emu/disassembler", "ui/disassembler"]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Everything is work in progress. We will update this document a lot of times in t
 
 ## Collaborative Guidelines
 
-We love collaborating with others, so feel free to interact with us however you want. First of all, we strongly suggest you to enter in our Discord channel where you can find all of us ([here](https://discord.com/channels/919139369774891088/1013367016666714112)). 
+We love collaborating with others, so feel free to interact with us however you want. First of all, we strongly suggest you to enter in our Discord channel where you can find all of us ([here](https://discord.com/channels/919139369774891088/1013367016666714112)).
 
 [Contributing doc](./CONTRIBUTING.md)
 
@@ -23,11 +23,27 @@ We love collaborating with others, so feel free to interact with us however you 
 - clone the repository :)
 - we are using `just` and not `make` then if you want take the benefit of this install it `cargo install just`
 
-```bash
+```zsh
 # quick check all is working on you machine
 just build
 just test
 
 # run a .gba file
 cargo run -- ~/Desktop/my_game.gba
+```
+
+### Run
+
+```zsh
+just run <rom>
+```
+
+### Run with logger enabled {stdout or file}
+
+```zsh
+# log stdout
+just run-logger <rom>
+
+# log to file /tmp/clementine-{timestamp}.log
+just run-logger-file <rom>
 ```

--- a/emu/Cargo.toml
+++ b/emu/Cargo.toml
@@ -16,3 +16,4 @@ rand = "0.8.5"
 
 [features]
 logger = []
+disassembler = []

--- a/emu/Cargo.toml
+++ b/emu/Cargo.toml
@@ -15,6 +15,4 @@ pretty_assertions = "1.3.0"
 rand = "0.8.5"
 
 [features]
-debug = ["rand"]
-mode_5 = ["debug"]
-mode_3 = ["debug"]
+logger = []

--- a/emu/src/bus.rs
+++ b/emu/src/bus.rs
@@ -684,6 +684,7 @@ impl Bus {
         self.cycles_count += 1;
 
         // TODO: move this somewhere in the UI
+        #[cfg(feature = "logger")]
         log(format!("CPU Cycles: {}", self.cycles_count));
 
         // Step ppu, dma, interrupts, timers, etc...

--- a/emu/src/cpu/arm/instructions.rs
+++ b/emu/src/cpu/arm/instructions.rs
@@ -214,6 +214,7 @@ impl std::fmt::Display for ArmModeMultiplyLongVariant {
     }
 }
 
+#[cfg(feature = "disassembler")]
 impl ArmModeInstruction {
     pub(crate) fn disassembler(&self) -> String {
         match self {
@@ -713,6 +714,7 @@ impl std::fmt::Display for ArmModeInstruction {
 }
 
 #[cfg(test)]
+#[cfg(feature = "disassembler")]
 mod tests {
     use super::*;
     use pretty_assertions::assert_eq;

--- a/emu/src/cpu/arm/operations.rs
+++ b/emu/src/cpu/arm/operations.rs
@@ -1057,8 +1057,11 @@ mod tests {
                 }
             );
 
-            let asm = op_code.instruction.disassembler();
-            assert_eq!(asm, "TEQ R12, #1");
+            #[cfg(feature = "disassembler")]
+            {
+                let asm = op_code.instruction.disassembler();
+                assert_eq!(asm, "TEQ R12, #1");
+            }
 
             cpu.registers.set_register_at(12, 0xFFFFFFFF);
             assert!(!cpu.cpsr.sign_flag());
@@ -1087,8 +1090,11 @@ mod tests {
             );
 
             assert!(!cpu.cpsr.can_execute(op_code.condition));
-            let asm = op_code.instruction.disassembler();
-            assert_eq!(asm, "MSREQ CPSR, R12");
+            #[cfg(feature = "disassembler")]
+            {
+                let asm = op_code.instruction.disassembler();
+                assert_eq!(asm, "MSREQ CPSR, R12");
+            }
         }
 
         let op_code = 0b1110_00_0_1001_1_1001_0011_000000000000;
@@ -1137,9 +1143,11 @@ mod tests {
             }
         );
 
-        let asm = op_code.instruction.disassembler();
-        assert_eq!(asm, "CMP R14, #0");
-
+        #[cfg(feature = "disassembler")]
+        {
+            let asm = op_code.instruction.disassembler();
+            assert_eq!(asm, "CMP R14, #0");
+        }
         assert!(!cpu.cpsr.sign_flag());
         assert!(!cpu.cpsr.zero_flag());
         assert!(!cpu.cpsr.carry_flag());
@@ -1174,8 +1182,11 @@ mod tests {
             );
 
             assert!(!cpu.cpsr.can_execute(op_code.condition));
-            let asm = op_code.instruction.disassembler();
-            assert_eq!(asm, "ORREQ R12, R12, #192");
+            #[cfg(feature = "disassembler")]
+            {
+                let asm = op_code.instruction.disassembler();
+                assert_eq!(asm, "ORREQ R12, R12, #192");
+            }
         }
     }
 
@@ -1199,8 +1210,11 @@ mod tests {
             );
 
             assert!(!cpu.cpsr.can_execute(op_code.condition));
-            let asm = op_code.instruction.disassembler();
-            assert_eq!(asm, "MOVEQ R14, #4");
+            #[cfg(feature = "disassembler")]
+            {
+                let asm = op_code.instruction.disassembler();
+                assert_eq!(asm, "MOVEQ R14, #4");
+            }
         }
         {
             let op_code: u32 = 0b1110_00_1_1101_0_0000_0000_000011011111;
@@ -1222,8 +1236,11 @@ mod tests {
                 }
             );
 
-            let asm = op_code.instruction.disassembler();
-            assert_eq!(asm, "MOV R0, #223");
+            #[cfg(feature = "disassembler")]
+            {
+                let asm = op_code.instruction.disassembler();
+                assert_eq!(asm, "MOV R0, #223");
+            }
 
             cpu.registers.set_register_at(0, 1);
             assert!(!cpu.cpsr.sign_flag());
@@ -1254,8 +1271,11 @@ mod tests {
                 }
             );
 
-            let asm = op_code.instruction.disassembler();
-            assert_eq!(asm, "MOV R12, #67108864");
+            #[cfg(feature = "disassembler")]
+            {
+                let asm = op_code.instruction.disassembler();
+                assert_eq!(asm, "MOV R12, #67108864");
+            }
 
             cpu.registers.set_register_at(12, 1);
             assert!(!cpu.cpsr.sign_flag());
@@ -1290,8 +1310,11 @@ mod tests {
                 }
             );
 
-            let asm = op_code.instruction.disassembler();
-            assert_eq!(asm, "ADD R0, R15, #1");
+            #[cfg(feature = "disassembler")]
+            {
+                let asm = op_code.instruction.disassembler();
+                assert_eq!(asm, "ADD R0, R15, #1");
+            }
 
             cpu.registers.set_register_at(15, 15);
             assert!(!cpu.cpsr.sign_flag());
@@ -2334,8 +2357,11 @@ mod tests {
                     offsetting: Offsetting::Up,
                 }
             );
-            let f = op_code.instruction.disassembler();
-            assert_eq!(f, "LDRB R12, #768");
+            #[cfg(feature = "disassembler")]
+            {
+                let f = op_code.instruction.disassembler();
+                assert_eq!(f, "LDRB R12, #768");
+            }
         }
         {
             let op_code = 0b1110_01_0_1_1_0_0_1_1111_1101_000011010000;
@@ -2354,8 +2380,11 @@ mod tests {
                     offsetting: Offsetting::Up,
                 }
             );
-            let f = op_code.instruction.disassembler();
-            assert_eq!(f, "LDR R13, #208");
+            #[cfg(feature = "disassembler")]
+            {
+                let f = op_code.instruction.disassembler();
+                assert_eq!(f, "LDR R13, #208");
+            }
         }
         {
             let op_code = 0b1110_01_0_1_1_0_0_1_1111_1101_000010111000;
@@ -2374,8 +2403,11 @@ mod tests {
                     offsetting: Offsetting::Up,
                 }
             );
-            let f = op_code.instruction.disassembler();
-            assert_eq!(f, "LDR R13, #184");
+            #[cfg(feature = "disassembler")]
+            {
+                let f = op_code.instruction.disassembler();
+                assert_eq!(f, "LDR R13, #184");
+            }
         }
         {
             let op_code = 0b1110_01_0_1_1_0_0_1_1111_1101_000011010000;
@@ -2394,8 +2426,11 @@ mod tests {
                     offsetting: Offsetting::Up,
                 }
             );
-            let f = op_code.instruction.disassembler();
-            assert_eq!(f, "LDR R13, #208");
+            #[cfg(feature = "disassembler")]
+            {
+                let f = op_code.instruction.disassembler();
+                assert_eq!(f, "LDR R13, #208");
+            }
         }
         {
             let op_code = 0b1110_0101_1101_1111_1101_0000_0001_1000;
@@ -2415,8 +2450,11 @@ mod tests {
                     offsetting: Offsetting::Up,
                 }
             );
-            let f = op_code.instruction.disassembler();
-            assert_eq!(f, "LDRB R13, #24");
+            #[cfg(feature = "disassembler")]
+            {
+                let f = op_code.instruction.disassembler();
+                assert_eq!(f, "LDRB R13, #24");
+            }
 
             // because in this specific case address will be
             // then will be 0x03000050 (.wrapping_add(offset))
@@ -2450,8 +2488,11 @@ mod tests {
                     offsetting: Offsetting::Up,
                 }
             );
-            let f = op_code.instruction.disassembler();
-            assert_eq!(f, "STRB R4, #520");
+            #[cfg(feature = "disassembler")]
+            {
+                let f = op_code.instruction.disassembler();
+                assert_eq!(f, "STRB R4, #520");
+            }
         }
         {
             let op_code: u32 = 0b1110_0101_1000_0001_0001_0000_0000_0000;
@@ -2471,9 +2512,11 @@ mod tests {
                     offsetting: Offsetting::Up,
                 }
             );
-            let f = op_code.instruction.disassembler();
-            assert_eq!(f, "STR R1, #0");
-
+            #[cfg(feature = "disassembler")]
+            {
+                let f = op_code.instruction.disassembler();
+                assert_eq!(f, "STR R1, #0");
+            }
             cpu.registers.set_register_at(1, 16843009);
 
             // because in this specific case address will be
@@ -2508,8 +2551,11 @@ mod tests {
                     offsetting: Offsetting::Up,
                 }
             );
-            let f = op_code.instruction.disassembler();
-            assert_eq!(f, "STRB R13, #24");
+            #[cfg(feature = "disassembler")]
+            {
+                let f = op_code.instruction.disassembler();
+                assert_eq!(f, "STRB R13, #24");
+            }
 
             // because in this specific case address will be
             // then will be 0x03000050 (.wrapping_add(offset))

--- a/emu/src/cpu/arm7tdmi.rs
+++ b/emu/src/cpu/arm7tdmi.rs
@@ -1,5 +1,6 @@
 use std::convert::TryInto;
 
+#[cfg(feature = "logger")]
 use logger::log;
 use vecfixed::VecFixed;
 
@@ -453,8 +454,9 @@ impl Arm7tdmi {
                         return;
                     }
 
+                    #[cfg(feature = "logger")]
                     let current_ins = self.registers.program_counter() - 4;
-
+                    #[cfg(feature = "logger")]
                     log(format!("PC: 0x{current_ins:X} {decoded}"));
 
                     self.execute_thumb(decoded);
@@ -483,8 +485,9 @@ impl Arm7tdmi {
                         return;
                     }
 
+                    #[cfg(feature = "logger")]
                     let current_ins = self.registers.program_counter() - 4;
-
+                    #[cfg(feature = "logger")]
                     log(format!("PC: 0x{current_ins:X} {decoded}"));
 
                     self.execute_arm(decoded);

--- a/emu/src/cpu/arm7tdmi.rs
+++ b/emu/src/cpu/arm7tdmi.rs
@@ -463,7 +463,7 @@ impl Arm7tdmi {
                 }
 
                 // This means that the instruction flushed the pipeline
-                if matches!(self.fetched_thumb, None) {
+                if self.fetched_thumb.is_none() {
                     return;
                 }
 
@@ -494,7 +494,7 @@ impl Arm7tdmi {
                 }
 
                 // This means that the instruction flushed the pipeline
-                if matches!(self.fetched_arm, None) {
+                if self.fetched_arm.is_none() {
                     return;
                 }
 

--- a/emu/src/cpu/arm7tdmi.rs
+++ b/emu/src/cpu/arm7tdmi.rs
@@ -2,6 +2,8 @@ use std::convert::TryInto;
 
 #[cfg(feature = "logger")]
 use logger::log;
+
+#[cfg(feature = "disassembler")]
 use vecfixed::VecFixed;
 
 use crate::bitwise::Bits;
@@ -27,6 +29,7 @@ pub struct Arm7tdmi {
 
     pub register_bank: RegisterBank,
 
+    #[cfg(feature = "disassembler")]
     pub disassembler_buffer: VecFixed<1000, String>,
 
     fetched_arm: Option<u32>,
@@ -113,6 +116,7 @@ impl Default for Arm7tdmi {
             spsr: Psr::default(),
             registers: Registers::default(),
             register_bank: RegisterBank::default(),
+            #[cfg(feature = "disassembler")]
             disassembler_buffer: VecFixed::new(),
             fetched_arm: None,
             decoded_arm: None,
@@ -169,13 +173,16 @@ impl Arm7tdmi {
             return;
         }
 
-        let decimal_value = self.registers.program_counter();
-        let padded_hex_value = format!("{decimal_value:#04X}");
-        self.disassembler_buffer.push(format!(
-            "{}: {}",
-            padded_hex_value,
-            op_code.instruction.disassembler()
-        ));
+        #[cfg(feature = "disassembler")]
+        {
+            let decimal_value = self.registers.program_counter();
+            let padded_hex_value = format!("{decimal_value:#04X}");
+            self.disassembler_buffer.push(format!(
+                "{}: {}",
+                padded_hex_value,
+                op_code.instruction.disassembler()
+            ));
+        }
 
         match op_code.instruction {
             ArmModeInstruction::DataProcessing {
@@ -302,12 +309,15 @@ impl Arm7tdmi {
     }
 
     pub fn execute_thumb(&mut self, op_code: ThumbModeOpcode) {
-        let decimal_value = self.registers.program_counter();
-        let padded_hex_value = format!("{decimal_value:#04X}");
-        self.disassembler_buffer.push(format!(
-            "{padded_hex_value}: {}",
-            op_code.instruction.disassembler()
-        ));
+        #[cfg(feature = "disassembler")]
+        {
+            let decimal_value = self.registers.program_counter();
+            let padded_hex_value = format!("{decimal_value:#04X}");
+            self.disassembler_buffer.push(format!(
+                "{padded_hex_value}: {}",
+                op_code.instruction.disassembler()
+            ));
+        }
 
         match op_code.instruction {
             ThumbModeInstruction::MoveShiftedRegister {

--- a/emu/src/cpu/thumb/instruction.rs
+++ b/emu/src/cpu/thumb/instruction.rs
@@ -1,6 +1,7 @@
 use crate::bitwise::Bits;
 use crate::cpu::condition::Condition;
 use crate::cpu::flags::{LoadStoreKind, OperandKind, Operation, ReadWriteKind, ShiftKind};
+#[cfg(feature = "disassembler")]
 use crate::cpu::registers::REG_PROGRAM_COUNTER;
 use crate::cpu::thumb::alu_instructions::{ThumbHighRegisterOperation, ThumbModeAluInstruction};
 use logger::log;
@@ -239,6 +240,7 @@ impl std::fmt::Display for ThumbModeInstruction {
     }
 }
 
+#[cfg(feature = "disassembler")]
 impl ThumbModeInstruction {
     pub(crate) fn disassembler(&self) -> String {
         match self {
@@ -460,6 +462,7 @@ impl ThumbModeInstruction {
     }
 }
 
+#[cfg(feature = "disassembler")]
 #[cfg(test)]
 mod test {
     use super::*;

--- a/emu/src/render/color.rs
+++ b/emu/src/render/color.rs
@@ -31,7 +31,6 @@ impl Color {
     }
 }
 
-#[cfg(feature = "debug")]
 impl From<Color> for [u8; 2] {
     fn from(color: Color) -> Self {
         [(color.0 >> 8) as u8, color.0 as u8]

--- a/emu/src/render/ppu.rs
+++ b/emu/src/render/ppu.rs
@@ -1,10 +1,5 @@
 use std::sync::{Arc, Mutex};
 
-#[cfg(feature = "debug")]
-use crate::render::GBC_LCD_WIDTH;
-#[cfg(feature = "debug")]
-use rand::Rng;
-
 use crate::{
     cpu::arm7tdmi::Arm7tdmi,
     render::{
@@ -149,54 +144,6 @@ impl PixelProcessUnit {
             }
         }
         palettes
-    }
-
-    #[cfg(feature = "debug")]
-    pub fn load_random_palettes(&mut self) {
-        let mut memory = self.internal_memory.lock().unwrap();
-
-        for i in 0..200 {
-            let mut rng = rand::thread_rng();
-            let mut value: u8 = rng.gen();
-            memory.bg_palette_ram[i] = value;
-            value = rng.gen();
-            memory.obj_palette_ram[i] = value;
-        }
-    }
-
-    #[cfg(feature = "debug")]
-    pub fn load_centered_bitmap(&mut self, data: Vec<Color>, width: usize, height: usize) {
-        let mut memory = self.internal_memory.lock().unwrap();
-
-        let centered_width = (LCD_WIDTH - width) / 2;
-        let mut row = (LCD_HEIGHT - height) / 2;
-        for i in 0..data.len() {
-            let array_color: [u8; 2] = data[i].into();
-            if i % width == 0 {
-                row += 1;
-            }
-
-            let color_index = ((i % width + centered_width) + (row * LCD_WIDTH)) * 2;
-            memory.video_ram[color_index] = array_color[0];
-            memory.video_ram[color_index + 1] = array_color[1];
-        }
-    }
-
-    #[cfg(feature = "debug")]
-    pub fn load_gbc_bitmap(&mut self, data: Vec<Color>, width: usize, height: usize) {
-        let mut memory = self.internal_memory.lock().unwrap();
-
-        let mut row = 0;
-        for i in 0..data.len() {
-            let array_color: [u8; 2] = data[i].into();
-            if i % width == 0 {
-                row += 1;
-            }
-
-            let color_index = ((i % width) + (row * GBC_LCD_WIDTH)) * 2;
-            memory.video_ram[color_index] = array_color[0];
-            memory.video_ram[color_index + 1] = array_color[1];
-        }
     }
 }
 

--- a/justfile
+++ b/justfile
@@ -10,20 +10,6 @@ build:
 test:
     @cargo test --workspace
 
-set positional-arguments
-
-# run clemente in DEBUG mode
-@debug *args='':
-    @cargo run --features debug -- $1
-
-# run clemente in DEBUG mode
-@test_mode_3 *args='':
-    @cargo run --features test_bitmap_3 -- $1
-
-# run clemente in DEBUG mode
-@test_mode_5 *args='':
-    @cargo run --features test_bitmap_5 -- $1
-
 # run clippy with heavy config
 lint:
     @cargo clippy --workspace -- -D warnings    \

--- a/justfile
+++ b/justfile
@@ -8,7 +8,7 @@ build:
 
 # run test on all workspace
 test:
-    @cargo test --workspace
+    @cargo test --workspace --all-features
 
 # run clippy with heavy config
 lint:

--- a/justfile
+++ b/justfile
@@ -29,3 +29,6 @@ check-fmt:
 
 fmt:
     @cargo fmt
+set positional-arguments
+run rom:
+    @cargo run $1

--- a/justfile
+++ b/justfile
@@ -29,6 +29,11 @@ check-fmt:
 
 fmt:
     @cargo fmt
+
 set positional-arguments
+
 run rom:
     @cargo run $1
+
+run-logger rom:
+    @cargo run --features logger $1

--- a/justfile
+++ b/justfile
@@ -37,3 +37,6 @@ run rom:
 
 run-logger rom:
     @cargo run --features logger $1
+
+run-disassembler rom:
+    @cargo run --features disassembler $1

--- a/logger/Cargo.toml
+++ b/logger/Cargo.toml
@@ -8,3 +8,6 @@ license.workspace = true
 [dependencies]
 chrono = "0.4.23"
 once_cell = "1.17.0"
+
+[features]
+logger = []

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -1,3 +1,8 @@
+#[cfg(feature = "logger")]
+use chrono::Utc;
+#[cfg(feature = "logger")]
+use once_cell::sync::OnceCell;
+#[cfg(feature = "logger")]
 use std::{
     fs::File,
     io::{self, Write},
@@ -5,16 +10,16 @@ use std::{
     time::Instant,
 };
 
-use chrono::Utc;
-use once_cell::sync::OnceCell;
-
+#[cfg(feature = "logger")]
 static LOGGER: OnceCell<Logger> = OnceCell::new();
 
+#[cfg(feature = "logger")]
 struct LoggerImpl {
     pub sink: Box<dyn Write + Send>,
     pub start_instant: Instant,
 }
 
+#[cfg(feature = "logger")]
 impl LoggerImpl {
     fn new(kind: LogKind) -> Self {
         let start_instant = Instant::now();
@@ -65,10 +70,12 @@ pub enum LogKind {
 }
 
 /// Logger
+#[cfg(feature = "logger")]
 struct Logger {
     pub inner_impl: Mutex<LoggerImpl>,
 }
 
+#[cfg(feature = "logger")]
 impl Default for Logger {
     fn default() -> Self {
         Self {
@@ -77,6 +84,7 @@ impl Default for Logger {
     }
 }
 
+#[cfg(feature = "logger")]
 impl Logger {
     fn new(kind: LogKind) -> Self {
         Self {
@@ -94,6 +102,7 @@ impl Logger {
     }
 }
 
+#[cfg(feature = "logger")]
 pub fn init_logger(kind: LogKind) {
     LOGGER.set(Logger::new(kind)).ok();
 }
@@ -102,9 +111,12 @@ pub fn log<T>(data: T)
 where
     T: std::fmt::Display,
 {
+    let _ = data;
+    #[cfg(feature = "logger")]
     LOGGER.get().map_or((), |logger| logger.log(data));
 }
 
+#[cfg(feature = "logger")]
 #[cfg(test)]
 mod tests {
     use std::fs;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,24 +1,22 @@
 extern crate ui;
 use ui::app::ClementineApp;
 extern crate logger;
-use logger::{init_logger, log, LogKind};
+use logger::log;
+
+#[cfg(feature = "logger")]
+use logger::{init_logger, LogKind};
 
 fn main() {
-    let mut args = std::env::args().skip(1).collect::<Vec<String>>();
+    let args = std::env::args().skip(1).collect::<Vec<String>>();
 
+    #[cfg(feature = "logger")]
     if args.len() > 1 {
-        let arg = args.remove(0);
-        if arg.as_str() == "--log-on-file" {
+        if args.last().unwrap().as_str() == "--log-on-file" {
             init_logger(LogKind::FILE);
-        } else {
-            eprintln!("arguments not recognized.");
-            std::process::exit(1);
         }
     } else {
         init_logger(LogKind::STDOUT);
     }
-
-    log("clementine v0.1.0");
 
     let cartridge_name = args.first().map_or_else(
         || {

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -12,3 +12,6 @@ egui = { version = "0.22.0", default-features = false }
 egui_extras = { version = "0.22.0", features = ["image"] }
 emu = { path = "../emu"}
 image = { version = "0.24.5", features = ["png"], optional = true}
+
+[features]
+disassembler = []

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -12,20 +12,3 @@ egui = { version = "0.22.0", default-features = false }
 egui_extras = { version = "0.22.0", features = ["image"] }
 emu = { path = "../emu"}
 image = { version = "0.24.5", features = ["png"], optional = true}
-
-[features]
-debug = ["emu/debug"]
-test_bitmap_3 = [ 
-    "debug", 
-    "emu/mode_3" , 
-    "egui_extras/image", 
-    "image"
-]
-
-test_bitmap_5 = [ 
-    "debug", 
-    "emu/mode_5" , 
-    "egui_extras/image", 
-    "image"
-]
-

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "disassembler")]
 use crate::disassembler::Disassembler;
 use emu::{cartridge_header::CartridgeHeader, gba::Gba};
 use logger::log;
@@ -47,16 +48,23 @@ impl ClementineApp {
             data,
         )));
 
+        #[cfg(feature = "disassembler")]
         let disassembler = Disassembler::new(Arc::clone(&arc_gba));
 
-        Self::from_tools(vec![
+        let tools: Vec<Box<dyn UiTool>> = vec![
             Box::<about::About>::default(),
             Box::new(CpuRegisters::new(Arc::clone(&arc_gba))),
             Box::new(CpuHandler::new(Arc::clone(&arc_gba))),
             Box::new(GbaDisplay::new(Arc::clone(&arc_gba))),
             Box::new(PaletteVisualizer::new(arc_gba)),
-            Box::new(disassembler),
-        ])
+        ];
+
+        #[cfg(feature = "disassembler")]
+        let mut tools = tools;
+        #[cfg(feature = "disassembler")]
+        tools.push(Box::new(disassembler));
+
+        Self::from_tools(tools)
     }
 
     fn from_tools(tools: Vec<Box<dyn UiTool>>) -> Self {
@@ -64,6 +72,7 @@ impl ClementineApp {
 
         open.insert(tools[1].name().to_owned());
         open.insert(tools[2].name().to_owned());
+        #[cfg(feature = "disassembler")]
         open.insert(tools[5].name().to_owned());
 
         Self { tools, open }

--- a/ui/src/disassembler.rs
+++ b/ui/src/disassembler.rs
@@ -1,9 +1,7 @@
-use std::sync::{Arc, Mutex};
-
+use crate::ui_traits::UiTool;
 use egui::{ScrollArea, TextEdit, TextStyle};
 use emu::gba::Gba;
-
-use crate::ui_traits::UiTool;
+use std::sync::{Arc, Mutex};
 
 pub struct Disassembler {
     gba: Arc<Mutex<Gba>>,

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -2,6 +2,7 @@ mod about;
 pub mod app;
 mod cpu_handler;
 mod cpu_registers;
+#[cfg(feature = "disassembler")]
 mod disassembler;
 mod gba_color;
 mod gba_display;

--- a/ui/src/palette_visualizer.rs
+++ b/ui/src/palette_visualizer.rs
@@ -59,14 +59,6 @@ impl UiTool for PaletteVisualizer {
 
         ui.label("Memory type:");
 
-        #[cfg(feature = "debug")]
-        if ui.button("RANDOM VALUES").clicked() {
-            if let Ok(mut gba) = self.gba.lock() {
-                #[cfg(feature = "debug")]
-                gba.ppu.load_random_palettes();
-            }
-        }
-
         ui.horizontal(|ui| {
             ui.radio_value(&mut self.palette_type, PaletteType::BG, "BG Palette");
             ui.spacing();

--- a/vecfixed/src/lib.rs
+++ b/vecfixed/src/lib.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 
-/// VecFixed is basically a vector that keep a fixed size. Every time new element is pushed
+/// `VecFixed` is basically a vector that keep a fixed size. Every time new element is pushed
 /// to the vector, the oldest element is removed and the latest pushed is added to the end.
 #[derive(Default)]
 pub struct VecFixed<const N: usize, T: Default + ToString> {
@@ -23,7 +23,7 @@ impl<const N: usize, T: Default + ToString> VecFixed<N, T> {
         let mut ret = Self::new();
 
         for _ in 0..N {
-            ret.push(value)
+            ret.push(value);
         }
 
         ret
@@ -39,7 +39,7 @@ impl<const N: usize, T: Default + ToString> VecFixed<N, T> {
         self.buffer.push_back(element);
     }
 
-    /// Join the elements of the VecFixed buffer into a string.
+    /// Join the elements of the `VecFixed` buffer into a string.
     pub fn join(&self, separator: &str) -> String {
         if self.buffer.is_empty() {
             return String::new();


### PR DESCRIPTION
- Just: Remove useless cmds
- Just: Add quick cmd for run rom
- Logger: Make logger a feature opt-in
- Doc: Update README
- UI: Make disassambler a feature opt-in

Those are the 3 different perf with no feature, logger and disassembler
![flamegraph](https://github.com/RIP-Comm/clementine/assets/41150432/fe3007d4-06ea-4780-b264-1f1dc71aeb40)

![flamegraph1](https://github.com/RIP-Comm/clementine/assets/41150432/9655bea9-8661-4fe6-971e-859c15e852d7)

![flamegraph0](https://github.com/RIP-Comm/clementine/assets/41150432/0c9d925b-eb90-47fd-9eb1-3e76e5ea48c1)


