### PR TITLE
Fix `LoadAddress`

### DIFF
--- a/emu/src/bitwise.rs
+++ b/emu/src/bitwise.rs
@@ -83,7 +83,7 @@ where
     /// Return false whenever there is a least one bit which is set to 0, true otherwise.
     /// When all bits are set to 1, the if statement fails and true is returned.
     fn are_bits_on(&self, bits_range: RangeInclusive<u8>) -> bool {
-        for (_, bit_index) in bits_range.enumerate() {
+        for bit_index in bits_range {
             if self.is_bit_off(bit_index) {
                 return false;
             }

--- a/emu/src/bus.rs
+++ b/emu/src/bus.rs
@@ -831,10 +831,10 @@ impl Bus {
             log("warning, read_word has address not word aligned");
         }
 
-        let part_0: u32 = self.read_raw(address).try_into().unwrap();
-        let part_1: u32 = self.read_raw(address + 1).try_into().unwrap();
-        let part_2: u32 = self.read_raw(address + 2).try_into().unwrap();
-        let part_3: u32 = self.read_raw(address + 3).try_into().unwrap();
+        let part_0: u32 = self.read_raw(address).into();
+        let part_1: u32 = self.read_raw(address + 1).into();
+        let part_2: u32 = self.read_raw(address + 2).into();
+        let part_3: u32 = self.read_raw(address + 3).into();
 
         part_3 << 24_u32 | part_2 << 16_u32 | part_1 << 8_u32 | part_0
     }
@@ -874,8 +874,8 @@ impl Bus {
             log("warning, read_half_word has address not half-word aligned");
         }
 
-        let part_0: u16 = self.read_raw(address).try_into().unwrap();
-        let part_1: u16 = self.read_raw(address + 1).try_into().unwrap();
+        let part_0: u16 = self.read_raw(address).into();
+        let part_1: u16 = self.read_raw(address + 1).into();
 
         part_1 << 8 | part_0
     }

--- a/emu/src/cpu/arm/alu_instruction.rs
+++ b/emu/src/cpu/arm/alu_instruction.rs
@@ -141,11 +141,17 @@ pub fn shift(kind: ShiftKind, shift_amount: u32, rm: u32, carry: bool) -> Arithm
                     ..Default::default()
                 },
                 // LSR#1..32: Normal right logical shift
-                1..=32 => ArithmeticOpResult {
-                    result: rm >> shift_amount,
-                    carry: rm.get_bit((shift_amount - 1).try_into().unwrap()),
-                    ..Default::default()
-                },
+                1..=32 => {
+                    // We do the shift in u64 for the same reason as above.
+                    let rm = rm as u64;
+                    let result = (rm >> shift_amount) as u32;
+
+                    ArithmeticOpResult {
+                        result,
+                        carry: rm.get_bit((shift_amount - 1).try_into().unwrap()),
+                        ..Default::default()
+                    }
+                }
                 _ => ArithmeticOpResult {
                     result: 0,
                     carry: false,
@@ -195,8 +201,8 @@ pub fn shift(kind: ShiftKind, shift_amount: u32, rm: u32, carry: bool) -> Arithm
 
                 // ROR#1..31: normal rotate right
                 1..=31 => ArithmeticOpResult {
-                    result: rm.rotate_right(shift_amount),
-                    carry: rm.get_bit((shift_amount - 1).try_into().unwrap()),
+                    result: rm.rotate_right(new_shift_amount),
+                    carry: rm.get_bit((new_shift_amount - 1).try_into().unwrap()),
                     ..Default::default()
                 },
 

--- a/emu/src/cpu/arm/operations.rs
+++ b/emu/src/cpu/arm/operations.rs
@@ -306,7 +306,7 @@ impl Arm7tdmi {
         }
     }
 
-    fn adc(&mut self, rd: usize, rn: u32, op2: u32, s: bool) {
+    pub fn adc(&mut self, rd: usize, rn: u32, op2: u32, s: bool) {
         let carry: u32 = self.cpsr.carry_flag().into();
 
         let first_op_result = Self::add_inner_op(rn, op2);

--- a/emu/src/cpu/arm/operations.rs
+++ b/emu/src/cpu/arm/operations.rs
@@ -327,7 +327,7 @@ impl Arm7tdmi {
         }
     }
 
-    fn sbc(&mut self, rd: usize, rn: u32, op2: u32, s: bool) {
+    pub fn sbc(&mut self, rd: usize, rn: u32, op2: u32, s: bool) {
         let carry: u32 = self.cpsr.carry_flag().into();
 
         let first_op_result = Self::sub_inner_op(rn, op2);

--- a/emu/src/cpu/arm7tdmi.rs
+++ b/emu/src/cpu/arm7tdmi.rs
@@ -1848,7 +1848,7 @@ mod tests {
                 }),
                 check_fn: Box::new(|cpu| {
                     let v = cpu.registers.register_at(1);
-                    assert_eq!(v, 18);
+                    assert_eq!(v, 16);
                 }),
             },
         ] {

--- a/emu/src/cpu/thumb/mode.rs
+++ b/emu/src/cpu/thumb/mode.rs
@@ -59,7 +59,7 @@ impl std::fmt::Display for ThumbModeOpcode {
             ThumbModeInstruction::SPRelativeLoadStore { .. } => {
                 "FMT: |1_0_0_1|L|_Rd__|_____Word8_____|"
             }
-            ThumbModeInstruction::LoadAddress { .. } => "FMT: |1_0_0_1|S|_Rd__|_____Word8_____|",
+            ThumbModeInstruction::LoadAddress { .. } => "FMT: |1_0_1_0|S|_Rd__|_____Word8_____|",
             ThumbModeInstruction::AddOffsetSP { .. } => "FMT: |1_0_1_1_0_0_0_0|S|____Word7____|",
             ThumbModeInstruction::PushPopReg { .. } => "FMT: |1_0_1_1|L|1_0|R|_____Rlist_____|",
             ThumbModeInstruction::MultipleLoadStore { .. } => {

--- a/emu/src/cpu/thumb/operations.rs
+++ b/emu/src/cpu/thumb/operations.rs
@@ -154,7 +154,7 @@ impl Arm7tdmi {
 
                 self.mov(destination, second_operand, true);
             }
-            ThumbModeAluInstruction::Adc => todo!(),
+            ThumbModeAluInstruction::Adc => self.adc(rd.into(), self.registers.register_at(rd.into()), rs, true),
             ThumbModeAluInstruction::Sbc => todo!(),
             ThumbModeAluInstruction::Ror => {
                 self.ror(rd.into(), rs);

--- a/emu/src/cpu/thumb/operations.rs
+++ b/emu/src/cpu/thumb/operations.rs
@@ -154,8 +154,12 @@ impl Arm7tdmi {
 
                 self.mov(destination, second_operand, true);
             }
-            ThumbModeAluInstruction::Adc => self.adc(rd.into(), self.registers.register_at(rd.into()), rs, true),
-            ThumbModeAluInstruction::Sbc => todo!(),
+            ThumbModeAluInstruction::Adc => {
+                self.adc(rd.into(), self.registers.register_at(rd.into()), rs, true)
+            }
+            ThumbModeAluInstruction::Sbc => {
+                self.sbc(rd.into(), self.registers.register_at(rd.into()), rs, true)
+            }
             ThumbModeAluInstruction::Ror => {
                 self.ror(rd.into(), rs);
             }

--- a/emu/src/cpu/thumb/operations.rs
+++ b/emu/src/cpu/thumb/operations.rs
@@ -432,7 +432,7 @@ impl Arm7tdmi {
             stack_pointer.wrapping_add(offset)
         } else {
             let mut pc = self.registers.program_counter() as u32;
-            pc.set_bit_off(0);
+            pc.set_bit_off(1);
             pc.wrapping_add(offset)
         };
 

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -113,7 +113,9 @@ where
 {
     let _ = data;
     #[cfg(feature = "logger")]
-    LOGGER.get().map_or((), |logger| logger.log(data));
+    if let Some(logger) = LOGGER.get() {
+        logger.log(data)
+    }
 }
 
 #[cfg(feature = "logger")]


### PR DESCRIPTION
In the `LoadAddress` Thumb instruction we were setting bit 0 to 0 while we should set bit 1 to zero, according to documentation.

I also did some small fixes around.