### PR TITLE
Fix memory align

### DIFF
--- a/emu/src/bus.rs
+++ b/emu/src/bus.rs
@@ -813,7 +813,7 @@ impl Bus {
         }
     }
 
-    pub fn read_word(&mut self, address: usize) -> u32 {
+    pub fn read_word(&mut self, mut address: usize) -> u32 {
         // TODO: here we have to see how many times to wait for the waitcycles
         // It depends on the bus width of the memory region
         // Right now we're assuming that every region has a bus width of 32 bits
@@ -829,6 +829,7 @@ impl Bus {
 
         if address & 3 != 0 {
             log("warning, read_word has address not word aligned");
+            address &= !3;
         }
 
         let part_0: u32 = self.read_raw(address).into();

--- a/emu/src/bus.rs
+++ b/emu/src/bus.rs
@@ -840,7 +840,7 @@ impl Bus {
         part_3 << 24_u32 | part_2 << 16_u32 | part_1 << 8_u32 | part_0
     }
 
-    pub fn write_word(&mut self, address: usize, value: u32) {
+    pub fn write_word(&mut self, mut address: usize, value: u32) {
         // TODO: Look at read_word
         for _ in 0..self.get_wait_cycles(address) {
             self.step();
@@ -850,6 +850,7 @@ impl Bus {
 
         if address & 3 != 0 {
             log("warning, write_word has address not word aligned");
+            address &= !3;
         }
 
         let part_0: u8 = value.get_bits(0..=7).try_into().unwrap();

--- a/emu/src/bus.rs
+++ b/emu/src/bus.rs
@@ -864,7 +864,7 @@ impl Bus {
         self.write_raw(address + 3, part_3);
     }
 
-    pub fn read_half_word(&mut self, address: usize) -> u16 {
+    pub fn read_half_word(&mut self, mut address: usize) -> u16 {
         // TODO: Look at read_word
         for _ in 0..self.get_wait_cycles(address) {
             self.step();
@@ -874,6 +874,7 @@ impl Bus {
 
         if address & 1 != 0 {
             log("warning, read_half_word has address not half-word aligned");
+            address &= !1;
         }
 
         let part_0: u16 = self.read_raw(address).into();
@@ -882,7 +883,7 @@ impl Bus {
         part_1 << 8 | part_0
     }
 
-    pub fn write_half_word(&mut self, address: usize, value: u16) {
+    pub fn write_half_word(&mut self, mut address: usize, value: u16) {
         // TODO: Look at read_word
         for _ in 0..self.get_wait_cycles(address) {
             self.step();
@@ -892,6 +893,7 @@ impl Bus {
 
         if address & 1 != 0 {
             log("warning, write_half_word has address not half-word aligned");
+            address &= !1;
         }
 
         let part_0: u8 = value.get_bits(0..=7).try_into().unwrap();

--- a/emu/src/cpu/arm/operations.rs
+++ b/emu/src/cpu/arm/operations.rs
@@ -2517,7 +2517,7 @@ mod tests {
                 let f = op_code.instruction.disassembler();
                 assert_eq!(f, "STR R1, #0");
             }
-            cpu.registers.set_register_at(1, 16843009);
+            cpu.registers.set_register_at(1, 16843008);
 
             // because in this specific case address will be
             // then will be 0x03000050 + 8 (.wrapping_sub(offset))
@@ -2527,10 +2527,10 @@ mod tests {
 
             let bus = cpu.bus;
 
-            assert_eq!(bus.read_raw(0x01010101), 1);
-            assert_eq!(bus.read_raw(0x01010101 + 1), 1);
-            assert_eq!(bus.read_raw(0x01010101 + 2), 1);
-            assert_eq!(bus.read_raw(0x01010101 + 3), 1);
+            assert_eq!(bus.read_raw(0x01010100), 0);
+            assert_eq!(bus.read_raw(0x01010100 + 1), 1);
+            assert_eq!(bus.read_raw(0x01010100 + 2), 1);
+            assert_eq!(bus.read_raw(0x01010100 + 3), 1);
             assert_eq!(cpu.registers.program_counter(), 0x03000050);
         }
         {

--- a/emu/src/cpu/arm7tdmi.rs
+++ b/emu/src/cpu/arm7tdmi.rs
@@ -926,11 +926,11 @@ mod tests {
         {
             // Immediate offset, pre-index, down, no wb, load, unsigned halfword
             let mut cpu = Arm7tdmi::default();
-            let op_code = 0b1110_000_1_0_1_0_1_0000_0001_0001_1_01_1_1111;
+            let op_code = 0b1110_000_1_0_1_0_1_0000_0001_0001_1_01_1_1100;
             let op_code: ArmModeOpcode = Arm7tdmi::decode(op_code);
 
             cpu.registers.set_register_at(0, 100);
-            cpu.bus.write_word(100 - 0b11111, 0xFFFF1234);
+            cpu.bus.write_word(100 - 0b11100, 0xFFFF1234);
 
             cpu.execute_arm(op_code);
 
@@ -940,30 +940,30 @@ mod tests {
         {
             // Immediate offset, pre-index, down, wb, load, unsigned halfword
             let mut cpu = Arm7tdmi::default();
-            let op_code = 0b1110_000_1_0_1_1_1_0000_0001_0001_1_01_1_1111;
+            let op_code = 0b1110_000_1_0_1_1_1_0000_0001_0001_1_01_1_1100;
             let op_code: ArmModeOpcode = Arm7tdmi::decode(op_code);
 
             cpu.registers.set_register_at(0, 100);
-            cpu.bus.write_word(100 - 0b11111, 0xFFFF1234);
+            cpu.bus.write_word(100 - 0b11100, 0xFFFF1234);
 
             cpu.execute_arm(op_code);
 
             assert_eq!(cpu.registers.register_at(1), 0x1234);
-            assert_eq!(cpu.registers.register_at(0), 100 - 0b11111);
+            assert_eq!(cpu.registers.register_at(0), 100 - 0b11100);
         }
         {
             // Immediate offset, pre-index, up, wb, load, unsigned halfword
             let mut cpu = Arm7tdmi::default();
-            let op_code = 0b1110_000_1_1_1_1_1_0000_0001_0001_1_01_1_1111;
+            let op_code = 0b1110_000_1_1_1_1_1_0000_0001_0001_1_01_1_1100;
             let op_code: ArmModeOpcode = Arm7tdmi::decode(op_code);
 
             cpu.registers.set_register_at(0, 100);
-            cpu.bus.write_word(100 + 0b11111, 0xFFFF1234);
+            cpu.bus.write_word(100 + 0b11100, 0xFFFF1234);
 
             cpu.execute_arm(op_code);
 
             assert_eq!(cpu.registers.register_at(1), 0x1234);
-            assert_eq!(cpu.registers.register_at(0), 100 + 0b11111);
+            assert_eq!(cpu.registers.register_at(0), 100 + 0b11100);
         }
         {
             // Immediate offset, post-index, down, no wb (but implicit), load, unsigned halfword
@@ -1038,14 +1038,14 @@ mod tests {
         {
             // Immediate offset, pre-index, down, no wb, store PC, unsigned halfword, base PC
             let mut cpu = Arm7tdmi::default();
-            let op_code = 0b1110_000_1_0_1_0_0_1111_1111_0001_1_01_1_1111;
+            let op_code = 0b1110_000_1_0_1_0_0_1111_1111_0001_1_01_1_1100;
             let op_code: ArmModeOpcode = Arm7tdmi::decode(op_code);
 
             cpu.registers.set_program_counter(500);
 
             cpu.execute_arm(op_code);
 
-            assert_eq!(cpu.bus.read_word(500 - 0b11111), 504);
+            assert_eq!(cpu.bus.read_word(500 - 0b11100), 504);
             assert_eq!(cpu.registers.program_counter(), 500);
         }
         {
@@ -1153,12 +1153,29 @@ mod tests {
                 ThumbModeInstruction::LoadStoreImmOffset
             );
 
+            cpu.registers.set_register_at(7, 4);
+            cpu.registers.set_register_at(0, 0xFFFFFFFF);
+            cpu.execute_thumb(op_code);
+
+            let mut bus = cpu.bus;
+            assert_eq!(bus.read_word(56), 0xFFFFFFFF);
+        }
+        {
+            // Store Word misaligned
+            let op_code = 0b0110_0011_0111_1000;
+            let mut cpu = Arm7tdmi::default();
+            let op_code: ThumbModeOpcode = Arm7tdmi::decode(op_code);
+            assert_eq!(
+                op_code.instruction,
+                ThumbModeInstruction::LoadStoreImmOffset
+            );
+
             cpu.registers.set_register_at(7, 2);
             cpu.registers.set_register_at(0, 0xFFFFFFFF);
             cpu.execute_thumb(op_code);
 
             let mut bus = cpu.bus;
-            assert_eq!(bus.read_word(54), 0xFFFFFFFF);
+            assert_eq!(bus.read_word(52), 0xFFFFFFFF);
         }
         {
             // Load Word


### PR DESCRIPTION
We were not aligning the address when reading/writing word.
Also, I noticed that when reading a misaligned address we should rotate the value so that the selected byte ends in bits 0-7 of the destination register.

Source:
<img width="673" alt="image" src="https://github.com/RIP-Comm/clementine/assets/5256712/b78b1989-6e09-46f6-a83c-f27f2e542158">


We should do the same for ARM as well. But we can wait until we run the ARM tests