### PR TITLE
Fix blockmemory

### DIFF
--- a/emu/src/cpu/thumb/operations.rs
+++ b/emu/src/cpu/thumb/operations.rs
@@ -500,6 +500,8 @@ impl Arm7tdmi {
 
         match load_store {
             LoadStoreKind::Store => {
+                let mut first_written = false;
+
                 for r in 0..=15 {
                     if register_list.is_bit_on(r) {
                         let value = self.registers.register_at(r as usize)
@@ -508,7 +510,16 @@ impl Arm7tdmi {
                                 thumb::operations::SIZE_OF_INSTRUCTION
                             } else {
                                 0
+                            }
+                            // If we store the base register as second register (or later) we store
+                            // the updated value as if it was already written back.
+                            + if first_written && r as usize == base_register {
+                                register_count * 4
+                            } else {
+                                0
                             };
+
+                        first_written = true;
 
                         self.bus.write_word(address as usize, value);
 


### PR DESCRIPTION
* Thumb: Correctly handles base in register list for multiple load/store
     This commit fixes thumb tests 230,231,232.
* Thumb: Correctly emulates undefined behavior when register list is empty in block load/store
    This should never happen but test rom has a test for it.
    This commit fixes tests 227 and 229.