### PR TITLE
Fix `MultipleLoadStore` ASM

### DIFF
--- a/emu/src/cpu/arm/instructions.rs
+++ b/emu/src/cpu/arm/instructions.rs
@@ -399,12 +399,13 @@ impl ArmModeInstruction {
                     Indexing::Post => "A",
                 };
 
-                let mut registers = String::new();
+                let mut regs = Vec::new();
                 for i in 0..=15 {
                     if register_list.get_bit(i) {
-                        registers.push_str(&format!("R{i}, "));
+                        regs.push(format!("R{i}"));
                     }
                 }
+                let registers = regs.join("- ");
 
                 let w = if *write_back { "!" } else { "" };
                 let f = if *load_psr { "^" } else { "" };

--- a/emu/src/cpu/arm/instructions.rs
+++ b/emu/src/cpu/arm/instructions.rs
@@ -405,7 +405,7 @@ impl ArmModeInstruction {
                         regs.push(format!("R{i}"));
                     }
                 }
-                let registers = regs.join("- ");
+                let registers = regs.join("-");
 
                 let w = if *write_back { "!" } else { "" };
                 let f = if *load_psr { "^" } else { "" };

--- a/emu/src/cpu/thumb/instruction.rs
+++ b/emu/src/cpu/thumb/instruction.rs
@@ -417,19 +417,18 @@ impl Instruction {
                     LoadStoreKind::Store => "PUSH",
                 };
 
-                let mut registers = String::new();
+                let mut regs = Vec::new();
                 for i in 0..=7 {
                     if register_list.get_bit(i) {
-                        registers.push_str(&format!("R{i}, "));
+                        regs.push(format!("R{i}"));
                     }
                 }
-
                 if *pc_lr {
-                    registers.push_str("PC");
+                    regs.push("PC".to_string());
                 } else {
-                    registers.push_str("LR");
+                    regs.push("LR".to_string());
                 }
-
+                let registers = regs.join("- ");
                 format!("{instr} {{{registers}}}")
             }
             Self::MultipleLoadStore {
@@ -442,13 +441,13 @@ impl Instruction {
                     LoadStoreKind::Store => "STMIA",
                 };
 
-                let mut registers = String::new();
+                let mut regs = Vec::new();
                 for i in 0..=7 {
                     if register_list.get_bit(i) {
-                        registers.push_str(&format!("R{i}, "));
+                        regs.push(format!("R{i}"));
                     }
                 }
-
+                let registers = regs.join("- ");
                 format!("{instr} R{base_register}!, {{{registers}}}")
             }
             Self::CondBranch {

--- a/emu/src/cpu/thumb/instruction.rs
+++ b/emu/src/cpu/thumb/instruction.rs
@@ -486,7 +486,7 @@ mod test {
             },
             output
         );
-        assert_eq!("LDMIA R1!, {R5, R7, }", output.disassembler());
+        assert_eq!("LDMIA R1!, {R5-R7}", output.disassembler());
     }
 
     #[test]
@@ -562,7 +562,7 @@ mod test {
             output
         );
 
-        assert_eq!("PUSH {R4, R5, R6, R7, PC}", output.disassembler());
+        assert_eq!("PUSH {R4-R5-R6-R7-PC}", output.disassembler());
     }
 
     #[test]

--- a/emu/src/cpu/thumb/instruction.rs
+++ b/emu/src/cpu/thumb/instruction.rs
@@ -428,7 +428,7 @@ impl Instruction {
                 } else {
                     regs.push("LR".to_string());
                 }
-                let registers = regs.join("- ");
+                let registers = regs.join("-");
                 format!("{instr} {{{registers}}}")
             }
             Self::MultipleLoadStore {
@@ -447,7 +447,7 @@ impl Instruction {
                         regs.push(format!("R{i}"));
                     }
                 }
-                let registers = regs.join("- ");
+                let registers = regs.join("-");
                 format!("{instr} R{base_register}!, {{{registers}}}")
             }
             Self::CondBranch {


### PR DESCRIPTION
This PR aims to make the improvements suggested on https://github.com/RIP-Comm/clementine/issues/190 by changing the register strings in the disassembler area from `{R0, R1, }` to `{R0-R1-R2...}`.

If approved, this PR closes https://github.com/RIP-Comm/clementine/issues/190.